### PR TITLE
Add copy for unsupported zipcodes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,17 @@
 class User < ActiveRecord::Base
+  SUPPORTED_ZIPCODES = %w[80221].freeze
+
   include Clearance::User
 
   validates :email, presence: true
   validates :password, presence: true
   validates :zipcode, presence: true
+
+  def supported?
+    SUPPORTED_ZIPCODES.include?(zipcode)
+  end
+
+  def zipcode=(zipcode)
+    super(zipcode.to_s.strip)
+  end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,1 +1,5 @@
-<%= t(".supported", zipcode: @profile.zipcode) %>
+<% if @profile.supported? %>
+  <%= t(".supported", zipcode: @profile.zipcode) %>
+<% else %>
+  <%= t(".unsupported", zipcode: @profile.zipcode) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,7 @@ en:
   profiles:
     show:
       supported: "%{zipcode} is a supported zipcode"
+      unsupported: "%{zipcode} isn't a supported zipcode. We'll notify you when Fresh Food Connect comes to your area."
 
   time:
     formats:

--- a/spec/features/donor_signs_up_spec.rb
+++ b/spec/features/donor_signs_up_spec.rb
@@ -3,13 +3,25 @@ require "rails_helper"
 feature "Donor signs up" do
   context "for supported zipcode" do
     scenario "they're notified and prompted for their address" do
-      supported_zipcode = "80221"
+      supported_zipcode = User::SUPPORTED_ZIPCODES.first
 
       visit root_path
       click_on_sign_up
       register_donor(email: "user@example.com", zipcode: supported_zipcode)
 
       expect(page).to have_supported_zipcode_text(supported_zipcode)
+    end
+  end
+
+  context "for unsupported zipcode" do
+    scenario "they're put on the waiting list" do
+      unsupported_zipcode = "90210"
+
+      visit root_path
+      click_on_sign_up
+      register_donor(email: "user@example.com", zipcode: unsupported_zipcode)
+
+      expect(page).to have_unsupported_zipcode_text(unsupported_zipcode)
     end
   end
 
@@ -25,6 +37,10 @@ feature "Donor signs up" do
         :password,
       ),
     )
+  end
+
+  def have_unsupported_zipcode_text(zipcode)
+    have_text t("profiles.show.unsupported", zipcode: zipcode)
   end
 
   def have_supported_zipcode_text(zipcode)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,4 +4,37 @@ describe User do
   it { should validate_presence_of(:email) }
   it { should validate_presence_of(:password) }
   it { should validate_presence_of(:zipcode) }
+
+  describe "#zipcode=" do
+    it "strips whitespace" do
+      user = User.new
+
+      user.zipcode = "     90210 "
+
+      expect(user.zipcode).to eq("90210")
+    end
+  end
+
+  describe "#supported?" do
+    context "when the zipcode is included in SUPPORTED_ZIPCODES" do
+      it "returns true" do
+        zipcode = User::SUPPORTED_ZIPCODES.first
+        user = build(:user, zipcode: zipcode)
+
+        supported = user.supported?
+
+        expect(supported).to be true
+      end
+    end
+
+    context "when the zipcode isn't included in SUPPORTED_ZIPCODES" do
+      it "returns false" do
+        user = build(:user, zipcode: "90210")
+
+        supported = user.supported?
+
+        expect(supported).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/TSEipEHK

When a `User`-provided zipcode is outside the list of supported zipcodes
(currently **ONLY** `80221`), they're notified.