### PR TITLE
Donor edits pickup location

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,0 +1,28 @@
+class LocationsController < ApplicationController
+  def create
+    @location = build_location
+
+    if update_location?
+      redirect_to profile_url
+    else
+      @profile = current_user
+
+      render "profiles/show"
+    end
+  end
+
+  private
+
+  def update_location?
+    @location.update(location_params) &&
+      current_user.update(zipcode: location_params[:zipcode])
+  end
+
+  def build_location
+    current_user.location || current_user.build_location
+  end
+
+  def location_params
+    params.require(:location).permit(:address, :notes, :zipcode)
+  end
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,0 +1,7 @@
+class Location < ActiveRecord::Base
+  belongs_to :user, touch: true
+
+  validates :address, presence: true
+  validates :user, presence: true
+  validates :zipcode, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ActiveRecord::Base
 
   include Clearance::User
 
+  has_one :location, dependent: :destroy
+
   validates :email, presence: true
   validates :password, presence: true
   validates :zipcode, presence: true

--- a/app/views/application/_navigation.html.erb
+++ b/app/views/application/_navigation.html.erb
@@ -1,0 +1,9 @@
+<nav>
+  <ul>
+    <li>
+      <%= link_to profile_path do %>
+        <%= t(".profile") %>
+      <% end %>
+    </li>
+  </ul>
+</nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,7 @@
 </head>
 <body class="<%= body_class %>">
   <%= render "flashes" -%>
+  <%= render "navigation" -%>
   <%= yield %>
   <%= render "javascript" %>
   <%= render "css_overrides" %>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -1,0 +1,7 @@
+<%= simple_form_for location, url: location_path do |f| %>
+  <%= f.input :address %>
+  <%= f.input :zipcode %>
+  <%= f.input :notes, as: :text %>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -3,3 +3,9 @@
 <% else %>
   <%= t(".unsupported", zipcode: @profile.zipcode) %>
 <% end %>
+
+<%= render("locations/form", location: @profile.location || @profile.build_location) %>
+
+<% if @profile.location.persisted? %>
+  <%= t(".pickup") %>
+<% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,5 @@
 Rails.application.configure do
+  config.middleware.use Clearance::BackDoor
   config.assets.raise_runtime_errors = true
   config.cache_classes = true
   config.eager_load = false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,8 @@
 en:
+  application:
+    navigation:
+      profile: "Profile"
+
   date:
     formats:
       default:
@@ -12,6 +16,7 @@ en:
 
   profiles:
     show:
+      pickup: "We pick up in your area on Thursdays from 9 until noon."
       supported: "%{zipcode} is a supported zipcode"
       unsupported: "%{zipcode} isn't a supported zipcode. We'll notify you when Fresh Food Connect comes to your area."
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,4 +1,9 @@
 en:
+  helpers:
+    submit:
+      location:
+        create: "Save Pickup Address"
+
   simple_form:
     "yes": 'Yes'
     "no": 'No'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resource :location, only: [:create]
   resource :profile, only: [:show]
 
   resources :passwords, controller: "clearance/passwords", only: [:create, :new]

--- a/db/migrate/20160325144643_create_locations.rb
+++ b/db/migrate/20160325144643_create_locations.rb
@@ -1,0 +1,11 @@
+class CreateLocations < ActiveRecord::Migration
+  def change
+    create_table :locations do |t|
+      t.string :address, null: false
+      t.string :zipcode, null: false
+      t.string :notes, null: false, default: ""
+
+      t.belongs_to :user, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160324194006) do
+ActiveRecord::Schema.define(version: 20160325144643) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,13 @@ ActiveRecord::Schema.define(version: 20160324194006) do
   end
 
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+
+  create_table "locations", force: :cascade do |t|
+    t.string  "address",              null: false
+    t.string  "zipcode",              null: false
+    t.string  "notes",   default: "", null: false
+    t.integer "user_id",              null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.datetime "created_at",                     null: false

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -6,7 +6,7 @@ if Rails.env.development? || Rails.env.test?
     task prime: "db:setup" do
       include FactoryGirl::Syntax::Methods
 
-      # create(:user, email: "user@example.com", password: "password")
+      create(:user, :supported, email: "user@example.com", password: "password")
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,6 +2,15 @@ FactoryGirl.define do
   factory :user do
     sequence(:email) { |i| "user#{i}@example.com" }
     password "password"
-    zipcode "80221"
+
+    supported
+
+    trait :supported do
+      zipcode "80221"
+    end
+
+    trait :unsupported do
+      zipcode "90210"
+    end
   end
 end

--- a/spec/features/donor_edits_location_spec.rb
+++ b/spec/features/donor_edits_location_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+feature "Donor edits location" do
+  scenario "from profile" do
+    donor = create(:user, zipcode: "90210")
+
+    visit root_path(as: donor)
+    click_on_profile
+    submit_pickup_location(
+      address: "123 Fake Street Denver CO",
+      zipcode: "80221",
+      notes: "on my porch",
+    )
+
+    expect(page).to have_pickup_time_text
+    expect(page).to have_supported_zipcode_text("80221")
+  end
+
+  context "when the location is invalid" do
+    scenario "it prompts the user for corrections" do
+      donor = create(:user)
+
+      visit profile_path(as: donor)
+      submit_pickup_location(address: "", zipcode: "")
+
+      expect(page).to have_address_errors
+    end
+  end
+
+  def have_supported_zipcode_text(zipcode)
+    have_text t("profiles.show.supported", zipcode: zipcode)
+  end
+
+  def click_on_profile
+    click_on t("application.navigation.profile")
+  end
+
+  def submit_pickup_location(address:, zipcode:, notes: "")
+    fill_form_and_submit(
+      :location,
+      :new,
+      address: address,
+      zipcode: zipcode,
+      notes: notes,
+    )
+  end
+
+  def have_pickup_time_text
+    have_text t("profiles.show.pickup")
+  end
+
+  def have_address_errors
+    have_text "can't be blank"
+  end
+end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+describe Location do
+  it { should belong_to(:user).touch(true) }
+
+  it { should validate_presence_of(:address) }
+  it { should validate_presence_of(:user) }
+  it { should validate_presence_of(:zipcode) }
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 describe User do
+  it { should have_one(:location).dependent(:destroy) }
   it { should validate_presence_of(:email) }
   it { should validate_presence_of(:password) }
   it { should validate_presence_of(:zipcode) }


### PR DESCRIPTION
https://trello.com/c/2gBYccFO

When a Donor's zipcode is supported, they'll need to edit their pickup
address.

This commit adds a `has_one :location` relationship to the User model.
There's nothing technical preventing Users from having more than one
location, but for the sake of simplicity we're limiting locations to a
1-to-1.

When a donor (supported or not) updates their address' zipcode, it will
update their Profiles "global" zipcode, which is used to determine
whether or not they're supported.