### PR TITLE
Supported Zipcode Registration Flow

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,8 +1,6 @@
 class LocationsController < ApplicationController
-  def create
-    @location = build_location
-
-    if update_location?
+  def update
+    if location.update(location_params)
       redirect_to profile_url
     else
       @profile = current_user
@@ -13,13 +11,8 @@ class LocationsController < ApplicationController
 
   private
 
-  def update_location?
-    @location.update(location_params) &&
-      current_user.update(zipcode: location_params[:zipcode])
-  end
-
-  def build_location
-    current_user.location || current_user.build_location
+  def location
+    current_user.location
   end
 
   def location_params

--- a/app/controllers/marketing_controller.rb
+++ b/app/controllers/marketing_controller.rb
@@ -2,5 +2,6 @@ class MarketingController < ApplicationController
   skip_before_action :require_login
 
   def index
+    @pre_registration = PreRegistration.new
   end
 end

--- a/app/controllers/pre_registrations_controller.rb
+++ b/app/controllers/pre_registrations_controller.rb
@@ -1,0 +1,23 @@
+class PreRegistrationsController < ApplicationController
+  skip_before_action :require_login
+
+  def create
+    @pre_registration = build_pre_registration
+
+    if @pre_registration.valid?
+      redirect_to new_registration_url(zipcode: @pre_registration.zipcode)
+    else
+      redirect_to root_url
+    end
+  end
+
+  private
+
+  def build_pre_registration
+    PreRegistration.new(pre_registration_params)
+  end
+
+  def pre_registration_params
+    params.require(:pre_registration).permit(:zipcode)
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,44 @@
+class RegistrationsController < ApplicationController
+  skip_before_action :require_login
+
+  def new
+    if zipcode.present?
+      @registration = Registration.new(zipcode: zipcode)
+    else
+      redirect_to root_url
+    end
+  end
+
+  def create
+    @registration = build_registration
+
+    if @registration.save
+      sign_in(@registration.user)
+
+      redirect_to profile_url
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def zipcode
+    params[:zipcode]
+  end
+
+  def build_registration
+    Registration.new(registration_params)
+  end
+
+  def registration_params
+    params.require(:registration).
+      permit(
+        :address,
+        :email,
+        :name,
+        :password,
+        :zipcode,
+      )
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,0 @@
-class UsersController < Clearance::UsersController
-  private
-
-  def user_params
-    params.require(:user).permit(:email, :password, :zipcode)
-  end
-end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,7 +1,17 @@
 class Location < ActiveRecord::Base
+  SUPPORTED_ZIPCODES = %w[80221].freeze
+
   belongs_to :user, touch: true
 
   validates :address, presence: true
   validates :user, presence: true
   validates :zipcode, presence: true
+
+  def supported?
+    SUPPORTED_ZIPCODES.include?(zipcode)
+  end
+
+  def zipcode=(zipcode)
+    super(zipcode.to_s.strip)
+  end
 end

--- a/app/models/pre_registration.rb
+++ b/app/models/pre_registration.rb
@@ -1,0 +1,7 @@
+class PreRegistration
+  include ActiveModel::Model
+
+  attr_accessor :zipcode
+
+  validates :zipcode, presence: true
+end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1,0 +1,87 @@
+class Registration
+  include ActiveModel::Model
+
+  validate :location_is_supported, if: :present?
+  validates :name, presence: true
+
+  attr_accessor(
+    :address,
+    :email,
+    :name,
+    :password,
+    :zipcode,
+  )
+
+  delegate(
+    :email,
+    :email=,
+    :password,
+    :password=,
+    to: :user,
+  )
+
+  delegate(
+    :address,
+    :address=,
+    :zipcode,
+    :zipcode=,
+    to: :location,
+  )
+
+  def user
+    @user ||= User.new
+  end
+
+  def location
+    @location ||= user.build_location
+  end
+
+  def valid?
+    super
+
+    user.validate
+    location.validate
+
+    expose_errors
+
+    errors.empty?
+  end
+
+  def invalid?
+    !valid?
+  end
+
+  def save
+    if valid?
+      ActiveRecord::Base.transaction do
+        user.save!
+        location.save!
+      end
+    end
+  end
+
+  def save!
+    unless save
+      raise ActiveRecord::RecordInvalid.new(self)
+    end
+  end
+
+  private
+
+  def location_is_supported
+    unless location.supported?
+      errors[:zipcode] = I18n.t(".unsupported", zipcode: location.zipcode)
+    end
+  end
+
+  def expose_errors
+    map_errors_from(user)
+    map_errors_from(location)
+  end
+
+  def map_errors_from(relationship)
+    relationship.errors.each do |key, message|
+      errors[key] = message
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,19 +1,10 @@
 class User < ActiveRecord::Base
-  SUPPORTED_ZIPCODES = %w[80221].freeze
-
   include Clearance::User
 
   has_one :location, dependent: :destroy
 
   validates :email, presence: true
   validates :password, presence: true
-  validates :zipcode, presence: true
 
-  def supported?
-    SUPPORTED_ZIPCODES.include?(zipcode)
-  end
-
-  def zipcode=(zipcode)
-    super(zipcode.to_s.strip)
-  end
+  delegate :supported?, to: :location, allow_nil: true
 end

--- a/app/views/application/_main_header.html.erb
+++ b/app/views/application/_main_header.html.erb
@@ -10,6 +10,11 @@
       <ul>
         <% if signed_in? %>
           <li>
+            <%= link_to profile_path do %>
+              <%= t(".profile") %>
+            <% end %>
+          </li>
+          <li>
             <%= link_to sign_out_path, method: :delete do %>
               <%= t(".sign_out") %>
             <% end %>

--- a/app/views/application/_main_header.html.erb
+++ b/app/views/application/_main_header.html.erb
@@ -8,21 +8,19 @@
 
     <nav class="main-nav">
       <ul>
-        <li>
-          <%= link_to profile_path do %>
-            <%= t(".sign_in") %>
-          <% end %>
-        </li>
-        <li>
-          <%= link_to sign_up_path do %>
-            <%= t(".sign_up") %>
-          <% end %>
-        </li>
-        <li>
-          <%= link_to sign_out_path, method: :delete do %>
-            <%= t(".sign_out") %>
-          <% end %>
-        </li>
+        <% if signed_in? %>
+          <li>
+            <%= link_to sign_out_path, method: :delete do %>
+              <%= t(".sign_out") %>
+            <% end %>
+          </li>
+        <% else %>
+          <li>
+            <%= link_to sign_in_path do %>
+              <%= t(".sign_in") %>
+            <% end %>
+          </li>
+        <% end %>
       </ul>
     </nav>
   </div>

--- a/app/views/marketing/index.html.erb
+++ b/app/views/marketing/index.html.erb
@@ -4,10 +4,8 @@
   <div class="content-wrapper-narrow">
     <h2><%= t(".heading") %></h2>
     <p class="hero__subheading"><%= t(".subheading") %></p>
-    <form action="">
-      <input type="text">
-      <input type="submit">
-    </form>
+
+    <%= render "pre_registrations/form", pre_registration: @pre_registration %>
   </div>
 </section>
 

--- a/app/views/pre_registrations/_form.html.erb
+++ b/app/views/pre_registrations/_form.html.erb
@@ -1,0 +1,5 @@
+<%= simple_form_for pre_registration do |f| %>
+  <%= f.input :zipcode %>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,18 +2,12 @@
 <%= render "application/welcome_modal" %>
 
 <div class="content-wrapper-narrow content-container">
-  <!--
-  <% if @profile.supported? %>
-    <%= t(".supported", zipcode: @profile.zipcode) %>
-  <% else %>
-    <%= t(".unsupported", zipcode: @profile.zipcode) %>
-  <% end %>
-  -->
-
   <header class="profile-header">
     <h2 class="profile-header__heading">firstName lastName</h2>
     <a class="profile-header__edit">Edit Profile</a>
   </header>
+
+  <%= render("locations/form", location: @profile.location || @profile.build_location) %>
 
   <section class="profile-section">
     <h3 class="profile-section__heading">Contact</h3>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -7,7 +7,7 @@
     <a class="profile-header__edit">Edit Profile</a>
   </header>
 
-  <%= render("locations/form", location: @profile.location || @profile.build_location) %>
+  <%= render("locations/form", location: @profile.location) %>
 
   <section class="profile-section">
     <h3 class="profile-section__heading">Contact</h3>

--- a/app/views/registrations/_form.html.erb
+++ b/app/views/registrations/_form.html.erb
@@ -1,0 +1,9 @@
+<%= simple_form_for registration do |f| %>
+  <%= f.input :name %>
+  <%= f.input :address %>
+  <%= f.input :zipcode %>
+  <%= f.input :email %>
+  <%= f.input :password %>
+
+  <%= f.submit %>
+<% end %>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,0 +1,10 @@
+<%= render "application/main_header" %>
+
+<section class="no-service-message">
+  <div class="content-wrapper-narrow content-container">
+    <h3><%= t(".supported.header") %></h3>
+    <p><%= t(".supported.prompt") %></p>
+
+    <%= render "registrations/form", registration: @registration %>
+  </div>
+</section>

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -1,4 +1,5 @@
 Clearance.configure do |config|
+  config.allow_sign_up = false
   config.mailer_sender = "team@freshfoodconnect.org"
   config.routes = false
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,8 +20,12 @@ en:
   profiles:
     show:
       pickup: "We pick up in your area on Thursdays from 9 until noon."
-      supported: "%{zipcode} is a supported zipcode"
-      unsupported: "%{zipcode} isn't a supported zipcode. We'll notify you when Fresh Food Connect comes to your area."
+
+  registrations:
+    new:
+      supported:
+        header: "Our service is available in your area!"
+        prompt: "In order to participate in our program, you'll need to create an account so we know where to come make the pickup and to let us know each week if you have veggies available to donate. Please provide us with some information below:"
 
   time:
     formats:
@@ -33,4 +37,6 @@ en:
         "%B %d"
 
   titles:
-    application: Freshfoodconnect
+    application: Fresh Food Connect
+
+  unsupported: "We're sorry, our service is not available in %{zipcode} at this time."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,8 +8,8 @@ en:
 
   application:
     main_header:
+      profile: "Profile"
       sign_in: "Sign In"
-      sign_up: "Sign Up"
       sign_out: "Sign Out"
 
   marketing:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -2,7 +2,11 @@ en:
   helpers:
     submit:
       location:
-        create: "Save Pickup Address"
+        update: "Save Pickup Address"
+      pre_registration:
+        create: "Donate"
+      registration:
+        create: "Sign Up"
 
   simple_form:
     "yes": 'Yes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   resource :location, only: [:create]
   resource :profile, only: [:show]
 
+  resources :registrations, only: [:create, :new]
+  resources :pre_registrations, only: [:create]
   resources :passwords, controller: "clearance/passwords", only: [:create, :new]
   resource :session, controller: "clearance/sessions", only: [:create]
 
@@ -13,7 +15,6 @@ Rails.application.routes.draw do
 
   get "/sign_in" => "clearance/sessions#new", as: "sign_in"
   delete "/sign_out" => "clearance/sessions#destroy", as: "sign_out"
-  get "/sign_up" => "clearance/users#new", as: "sign_up"
 
   constraints Clearance::Constraints::SignedIn.new do
     get "/" => redirect("/profile")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resource :location, only: [:create]
+  resource :location, only: [:update]
   resource :profile, only: [:show]
 
   resources :registrations, only: [:create, :new]

--- a/db/migrate/20160331202005_remove_zipcode_from_users.rb
+++ b/db/migrate/20160331202005_remove_zipcode_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveZipcodeFromUsers < ActiveRecord::Migration
+  def change
+    remove_index :users, column: :zipcode
+    remove_column :users, :zipcode, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160325144643) do
+ActiveRecord::Schema.define(version: 20160331202005) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,17 +33,18 @@ ActiveRecord::Schema.define(version: 20160325144643) do
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "locations", force: :cascade do |t|
-    t.string  "address",              null: false
-    t.string  "zipcode",              null: false
-    t.string  "notes",   default: "", null: false
-    t.integer "user_id",              null: false
+    t.string  "address",                                          null: false
+    t.string  "zipcode",                                          null: false
+    t.string  "notes",                               default: "", null: false
+    t.integer "user_id",                                          null: false
+    t.decimal "latitude",  precision: 15, scale: 10
+    t.decimal "longitude", precision: 15, scale: 10
   end
 
   create_table "users", force: :cascade do |t|
     t.datetime "created_at",                     null: false
     t.datetime "updated_at",                     null: false
     t.string   "email",                          null: false
-    t.string   "zipcode",                        null: false
     t.string   "encrypted_password", limit: 128, null: false
     t.string   "confirmation_token", limit: 128
     t.string   "remember_token",     limit: 128, null: false
@@ -51,6 +52,5 @@ ActiveRecord::Schema.define(version: 20160325144643) do
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["remember_token"], name: "index_users_on_remember_token", using: :btree
-  add_index "users", ["zipcode"], name: "index_users_on_zipcode", using: :btree
 
 end

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -6,7 +6,12 @@ if Rails.env.development? || Rails.env.test?
     task prime: "db:setup" do
       include FactoryGirl::Syntax::Methods
 
-      create(:user, :supported, email: "user@example.com", password: "password")
+      create(
+        :registration,
+        :supported,
+        email: "user@example.com",
+        password: "password",
+      )
     end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -29,5 +29,9 @@ FactoryGirl.define do
   factory :user do
     email
     password "password"
+
+    factory :donor do
+      location
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,16 +1,33 @@
 FactoryGirl.define do
-  factory :user do
-    sequence(:email) { |i| "user#{i}@example.com" }
+  sequence(:email) { |i| "user#{i}@example.com" }
+
+  trait :supported do
+    zipcode Location::SUPPORTED_ZIPCODES.first
+  end
+
+  trait :unsupported do
+    zipcode "90210"
+  end
+
+  factory :location do
+    address "123 Fake Street"
+
+    user
+
+    supported
+  end
+
+  factory :registration do
+    address "123 Fake Street"
+    name "New User"
     password "password"
 
     supported
+    email
+  end
 
-    trait :supported do
-      zipcode "80221"
-    end
-
-    trait :unsupported do
-      zipcode "90210"
-    end
+  factory :user do
+    email
+    password "password"
   end
 end

--- a/spec/features/donor_edits_location_spec.rb
+++ b/spec/features/donor_edits_location_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 feature "Donor edits location" do
   scenario "from profile" do
-    donor = create(:user, zipcode: "90210")
+    location = create(:location, zipcode: "80205")
+    donor = create(:user, location: location)
 
     visit root_path(as: donor)
     click_on_profile
@@ -13,12 +14,11 @@ feature "Donor edits location" do
     )
 
     expect(page).to have_pickup_time_text
-    expect(page).to have_supported_zipcode_text("80221")
   end
 
   context "when the location is invalid" do
     scenario "it prompts the user for corrections" do
-      donor = create(:user)
+      donor = create(:donor)
 
       visit profile_path(as: donor)
       submit_pickup_location(address: "", zipcode: "")
@@ -27,18 +27,14 @@ feature "Donor edits location" do
     end
   end
 
-  def have_supported_zipcode_text(zipcode)
-    have_text t("profiles.show.supported", zipcode: zipcode)
-  end
-
   def click_on_profile
-    click_on t("application.main_header.sign_in")
+    click_on t("application.main_header.profile")
   end
 
   def submit_pickup_location(address:, zipcode:, notes: "")
     fill_form_and_submit(
       :location,
-      :new,
+      :edit,
       address: address,
       zipcode: zipcode,
       notes: notes,

--- a/spec/features/donor_signs_up_spec.rb
+++ b/spec/features/donor_signs_up_spec.rb
@@ -13,17 +13,6 @@ feature "Donor signs up" do
     end
   end
 
-  context "for unsupported zipcode" do
-    scenario "they're put on the waiting list" do
-      unsupported_zipcode = "90210"
-
-      visit root_path
-      sign_up_with_zipcode(unsupported_zipcode)
-
-      expect(page).to have_unsupported_zipcode_text(unsupported_zipcode)
-    end
-  end
-
   def register_donor(address:)
     attributes = attributes_for(:registration).merge(address: address)
 

--- a/spec/features/donor_signs_up_spec.rb
+++ b/spec/features/donor_signs_up_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 feature "Donor signs up" do
   context "for supported zipcode" do
     scenario "they're notified and prompted for their address" do
-      supported_zipcode = User::SUPPORTED_ZIPCODES.first
+      supported_location = build(:location, :supported)
 
       visit root_path
-      click_on_sign_up
-      register_donor(email: "user@example.com", zipcode: supported_zipcode)
+      pre_register_with_zipcode(supported_location.zipcode)
+      register_donor(address: supported_location.address)
 
-      expect(page).to have_supported_zipcode_text(supported_zipcode)
+      expect(page).to have_pickup_text
     end
   end
 
@@ -18,25 +18,16 @@ feature "Donor signs up" do
       unsupported_zipcode = "90210"
 
       visit root_path
-      click_on_sign_up
-      register_donor(email: "user@example.com", zipcode: unsupported_zipcode)
+      sign_up_with_zipcode(unsupported_zipcode)
 
       expect(page).to have_unsupported_zipcode_text(unsupported_zipcode)
     end
   end
 
-  def register_donor(email:, zipcode:)
-    attributes = attributes_for(:user, email: email, zipcode: zipcode)
+  def register_donor(address:)
+    attributes = attributes_for(:registration).merge(address: address)
 
-    fill_form_and_submit(
-      :user,
-      :new,
-      attributes.slice(
-        :email,
-        :zipcode,
-        :password,
-      ),
-    )
+    fill_form_and_submit(:registration, :new, attributes)
   end
 
   def have_unsupported_zipcode_text(zipcode)
@@ -47,7 +38,11 @@ feature "Donor signs up" do
     have_text t("profiles.show.supported", zipcode: zipcode)
   end
 
-  def click_on_sign_up
-    click_on t("application.main_header.sign_up")
+  def pre_register_with_zipcode(zipcode)
+    fill_form_and_submit(:pre_registration, :new, zipcode: zipcode)
+  end
+
+  def have_pickup_text
+    have_text t("profiles.show.pickup")
   end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -6,4 +6,36 @@ describe Location do
   it { should validate_presence_of(:address) }
   it { should validate_presence_of(:user) }
   it { should validate_presence_of(:zipcode) }
+
+  describe "#supported?" do
+    context "when their zipcode is supported" do
+      it "returns true" do
+        location = build(:location, :supported)
+
+        supported = location.supported?
+
+        expect(supported).to be true
+      end
+    end
+
+    context "when their zipcode is unsupported" do
+      it "returns false" do
+        location = build(:location, :unsupported)
+
+        supported = location.supported?
+
+        expect(supported).to be false
+      end
+    end
+  end
+
+  describe "#zipcode=" do
+    it "trims whitespace" do
+      location = Location.new(zipcode: "    90210 ")
+
+      zipcode = location.zipcode
+
+      expect(zipcode).to eq("90210")
+    end
+  end
 end

--- a/spec/models/pre_registration_spec.rb
+++ b/spec/models/pre_registration_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+describe PreRegistration do
+  it { should validate_presence_of(:zipcode) }
+end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+describe Registration do
+  it { should validate_presence_of(:address) }
+  it { should validate_presence_of(:email) }
+  it { should validate_presence_of(:name) }
+  it { should validate_presence_of(:zipcode) }
+
+  describe "validations" do
+    describe "#supported?" do
+      context "when the Location is supported" do
+        it "is valid" do
+          location = attributes_for(:location, :supported)
+          registration = build(:registration, location.slice(:zipcode))
+
+          valid = registration.valid?
+
+          expect(valid).to be true
+          expect(registration.errors).to be_empty
+        end
+      end
+
+      context "when the Location is unsupported" do
+        it "is invalid" do
+          location = attributes_for(:location, :unsupported)
+          registration = build(:registration, location.slice(:zipcode))
+
+          valid = registration.valid?
+
+          expect(valid).to be false
+          expect(registration.errors[:zipcode]).not_to be_empty
+        end
+      end
+    end
+  end
+
+  describe "#save!" do
+    context "when invalid" do
+      it "raises an ActiveRecord::InvalidRecordError" do
+        registration = Registration.new
+
+        expect { registration.save! }.
+          to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+
+  describe "#save" do
+    context "when valid" do
+      it "creates a User with a Location" do
+        registration = build(:registration)
+
+        registration.save
+        user = registration.user
+        location = registration.location
+
+        expect(registration).to have_attributes(
+          valid?: true,
+          invalid?: false,
+        )
+        expect(user).to have_attributes(
+          email: registration.email,
+          location: location,
+          persisted?: true,
+          valid?: true,
+        )
+        expect(location).to have_attributes(
+          address: registration.address,
+          user: user,
+          zipcode: registration.zipcode,
+          persisted?: true,
+          valid?: true,
+        )
+      end
+    end
+
+    context "when invalid" do
+      it "exposes validation errors" do
+        registration = Registration.new
+
+        registration.save
+
+        expect(registration).to have_attributes(
+          valid?: false,
+          invalid?: true,
+        )
+        expect(registration.user).to have_attributes(
+          persisted?: false,
+          valid?: false,
+        )
+        expect(registration.location).to have_attributes(
+          persisted?: false,
+          valid?: false,
+        )
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,40 +2,9 @@ require "rails_helper"
 
 describe User do
   it { should have_one(:location).dependent(:destroy) }
+
   it { should validate_presence_of(:email) }
   it { should validate_presence_of(:password) }
-  it { should validate_presence_of(:zipcode) }
 
-  describe "#zipcode=" do
-    it "strips whitespace" do
-      user = User.new
-
-      user.zipcode = "     90210 "
-
-      expect(user.zipcode).to eq("90210")
-    end
-  end
-
-  describe "#supported?" do
-    context "when the zipcode is included in SUPPORTED_ZIPCODES" do
-      it "returns true" do
-        zipcode = User::SUPPORTED_ZIPCODES.first
-        user = build(:user, zipcode: zipcode)
-
-        supported = user.supported?
-
-        expect(supported).to be true
-      end
-    end
-
-    context "when the zipcode isn't included in SUPPORTED_ZIPCODES" do
-      it "returns false" do
-        user = build(:user, zipcode: "90210")
-
-        supported = user.supported?
-
-        expect(supported).to be false
-      end
-    end
-  end
+  it { should delegate_method(:supported?).to(:location) }
 end


### PR DESCRIPTION
https://trello.com/c/LP2n6hcq

This commit improves the registration flow.

First, potential donors enter their zipcode into the marketing page's
call to action.

This commit implements the flow for when a donor's zipcode is supported
by the program.

When potential donors are within the service area, they're prompted with
a registration form that asks for the typical `email` / `password`
combination, as well as their Name, Address, and Zipcode.

Once registration is complete, Users are redirected to their profile.

The bulk of the implementation depends on the `Registration` model,
which acts as a form object that wires together `User` and `Location`
instances.

---

**Improve Profile Editing Flow**

This commit adds temporary fixes to failing tests.

The profile page will be changed and improved upon in the near future,
so these changes might be temporary.
