### PR TITLE
Edit Pickup Location

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,5 +1,29 @@
 class ProfilesController < ApplicationController
   def show
-    @profile = current_user
+    @profile = build_profile
+  end
+
+  def edit
+    @profile = build_profile
+  end
+
+  def update
+    @profile = build_profile
+
+    if @profile.update(profile_params)
+      redirect_to profile_url
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def build_profile
+    Profile.new(user: current_user)
+  end
+
+  def profile_params
+    params.require(:profile).permit(:address, :notes, :zipcode)
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,50 @@
+class Profile
+  include ActiveModel::Model
+
+  attr_accessor :user
+
+  delegate(
+    :email,
+    :name,
+    :location,
+    to: :user,
+  )
+
+  delegate(
+    :address,
+    :address=,
+    :notes,
+    :notes=,
+    :zipcode,
+    :zipcode=,
+    :persisted?,
+    to: :location,
+  )
+
+  def update(attributes)
+    attributes.each do |method, value|
+      public_send("#{method}=", value)
+    end
+
+    if valid?
+      location.save
+    end
+  end
+
+  def valid?
+    super
+    location.validate
+
+    expose_errors
+
+    errors.empty?
+  end
+
+  private
+
+  def expose_errors
+    location.errors.each do |key, message|
+      errors[key] = message
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ActiveRecord::Base
   validates :password, presence: true
 
   delegate :supported?, to: :location, allow_nil: true
+
+  def name
+    "first last"
+  end
 end

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -1,5 +1,4 @@
-<form action="">
-
+<%= simple_form_for profile do |f| %>
   <fieldset class="profile-edit-section">
     <h3 class="profile-edit-section__heading">Name</h3>
     <label for="">Name</label>
@@ -14,10 +13,8 @@
 
   <fieldset class="profile-edit-section">
     <h3 class="profile-edit-section__heading">Location</h3>
-    <label for="">Street Address for Pickup</label>
-    <input type="text">
-    <label for="">Zipcode</label>
-    <input type="text">
+    <%= f.input :address %>
+    <%= f.input :zipcode %>
   </fieldset>
 
   <fieldset class="profile-edit-section">
@@ -36,8 +33,7 @@
       <option value="">Yes, I will be making a donation this week.</option>
       <option value="">No, I will not be making a donation this week.</option>
     </select>
-    <label for="">Pickup Notes</label>
-    <textarea name="" id="" cols="1" rows="3"></textarea>
+    <%= f.input :notes, as: :text %>
   </fieldset>
 
   <fieldset class="profile-edit-section">
@@ -57,4 +53,4 @@
   </fieldset>
 
   <input type="submit" value="Update Profile">
-</form>
+<% end %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render "application/main_header" %>
 
 <div class="content-wrapper-narrow content-container">
-  <%= render partial: '/profiles/form'%>
+  <%= render "profiles/form", profile: @profile %>
 </div>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -3,15 +3,17 @@
 
 <div class="content-wrapper-narrow content-container">
   <header class="profile-header">
-    <h2 class="profile-header__heading">firstName lastName</h2>
-    <a href="edit" class="profile-header__edit">Edit Profile</a>
+    <h2 class="profile-header__heading"><%= @profile.name %></h2>
+    <%= link_to edit_profile_path, class: "profile-header__edit" do %>
+      <%= t(".edit") %>
+    <% end %>
   </header>
 
   <section class="profile-section">
     <h3 class="profile-section__heading">Contact</h3>
     <dl>
       <dt>Email</dt>
-      <dd>user@example.com</dd>
+      <dd><%= @profile.email %></dd>
     </dl>
   </section>
 
@@ -20,11 +22,11 @@
     <dl>
       <div class="dl-group">
         <dt>Street Address for Pickup</dt>
-        <dd>1450 Example Address</dd>
+        <dd><%= @profile.address %></dd>
       </div>
       <div class="dl-group">
         <dt>Zip</dt>
-        <dd>80202</dd>
+        <dd><%= @profile.zipcode %></dd>
       </div>
     </dl>
   </section>
@@ -34,11 +36,7 @@
     <dl>
       <div class="dl-group">
         <dt>Scheduled Pickup Time</dt>
-        <dd>
-          <% if @profile.location.persisted? %>
-            <%= t(".pickup") %>
-          <% end %>
-        </dd>
+        <dd>We pick up in your area on Thursdays from 9 until noon.</dd>
       </div>
       <div class="dl-group">
         <dt>Donation Status for <span class="next-pickup-date">03/31/15</span></dt>
@@ -46,7 +44,7 @@
       </div>
       <div class="dl-group">
         <dt>Pickup Notes (e.g. On the table on the front porch)</dt>
-        <dd>Leaving my veggies on railing no the front porch.</dd>
+        <dd><%= @profile.notes %></dd>
       </div>
     </dl>
   </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,7 +25,7 @@ en:
 
   profiles:
     show:
-      pickup: "We pick up in your area on Thursdays from 9 until noon."
+      edit: "Edit Profile"
 
   registrations:
     new:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -5,6 +5,8 @@ en:
         update: "Save Pickup Address"
       pre_registration:
         create: "Donate"
+      profile:
+        update: "Update Profile"
       registration:
         create: "Sign Up"
       subscription:
@@ -21,6 +23,11 @@ en:
       # html: '<abbr title="required">*</abbr>'
     error_notification:
       default_message: "Please review the problems below:"
+    labels:
+      profile:
+        address: "Street Address for Pickup"
+        notes: "Pickup Notes"
+
     # Examples
     # labels:
     #   defaults:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
-  resource :location, only: [:update]
-  resource :profile, only: [:show, :edit]
+  resource :profile, only: [:show, :edit, :update]
 
   resources :pre_registrations, only: [:create]
   resources :registrations, only: [:create, :new]

--- a/db/migrate/20160401175730_change_location_notes_to_text.rb
+++ b/db/migrate/20160401175730_change_location_notes_to_text.rb
@@ -1,0 +1,9 @@
+class ChangeLocationNotesToText < ActiveRecord::Migration
+  def up
+    change_column :locations, :notes, :text
+  end
+
+  def down
+    change_column :locations, :notes, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160331234248) do
+ActiveRecord::Schema.define(version: 20160401175730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 20160331234248) do
   create_table "locations", force: :cascade do |t|
     t.string  "address",                                          null: false
     t.string  "zipcode",                                          null: false
-    t.string  "notes",                               default: "", null: false
+    t.text    "notes",                               default: "", null: false
     t.integer "user_id",                                          null: false
     t.decimal "latitude",  precision: 15, scale: 10
     t.decimal "longitude", precision: 15, scale: 10

--- a/spec/features/donor_edits_location_spec.rb
+++ b/spec/features/donor_edits_location_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+feature "Donor edits location" do
+  scenario "from profile" do
+    location = create(:location, zipcode: "80205")
+    donor = create(:user, location: location)
+    new_pickup_location = {
+      address: "123 Fake Street Denver CO",
+      zipcode: "80221",
+      notes: "on my porch",
+    }
+
+    visit root_path(as: donor)
+    click_on_profile
+    edit_pickup_location(new_pickup_location)
+
+    expect(page).to have_text(new_pickup_location[:address])
+    expect(page).to have_text(new_pickup_location[:zipcode])
+    expect(page).to have_text(new_pickup_location[:notes])
+  end
+
+  context "when the location is invalid" do
+    scenario "it prompts the user for corrections" do
+      donor = create(:donor)
+
+      visit profile_path(as: donor)
+      edit_pickup_location(address: "", zipcode: "")
+
+      expect(page).to have_address_errors
+    end
+  end
+
+  def click_on_profile
+    click_on t("application.main_header.profile")
+  end
+
+  def edit_pickup_location(address:, zipcode:, notes: "")
+    click_on t("profiles.show.edit")
+
+    fill_form_and_submit(
+      :profile,
+      :edit,
+      address: address,
+      zipcode: zipcode,
+      notes: notes,
+    )
+  end
+
+  def have_address_errors
+    have_text "can't be blank"
+  end
+end

--- a/spec/features/donor_signs_up_spec.rb
+++ b/spec/features/donor_signs_up_spec.rb
@@ -3,28 +3,22 @@ require "rails_helper"
 feature "Donor signs up" do
   context "for supported zipcode" do
     scenario "they're notified and prompted for their address" do
-      supported_location = build(:location, :supported)
+      supported_location = build_stubbed(:location, :supported)
+      user = supported_location.user
 
       visit root_path
       pre_register_with_zipcode(supported_location.zipcode)
-      register_donor(address: supported_location.address)
+      register_donor(address: supported_location.address, email: user.email)
 
-      expect(page).to have_pickup_text
+      expect(page).to have_text(user.email)
     end
   end
 
-  def register_donor(address:)
-    attributes = attributes_for(:registration).merge(address: address)
+  def register_donor(address:, email:)
+    attributes = attributes_for(:registration).
+      merge(address: address, email: email)
 
     fill_form_and_submit(:registration, :new, attributes)
-  end
-
-  def have_unsupported_zipcode_text(zipcode)
-    have_text t("profiles.show.unsupported", zipcode: zipcode)
-  end
-
-  def have_supported_zipcode_text(zipcode)
-    have_text t("profiles.show.supported", zipcode: zipcode)
   end
 
   def pre_register_with_zipcode(zipcode)

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe Profile do
+  it { should delegate_method(:location).to(:user) }
+  it { should delegate_method(:name).to(:user) }
+
+  it { should delegate_method(:address).to(:location) }
+  it { should delegate_method(:notes).to(:location) }
+  it { should delegate_method(:zipcode).to(:location) }
+
+  describe "#update" do
+    context "when valid" do
+      it "can update Location" do
+        location = build(
+          :location,
+          address: "original",
+          zipcode: "90210",
+          notes: "original",
+        )
+        profile = Profile.new(user: location.user)
+        updated_attributes = {
+          address: "new",
+          notes: "new",
+          zipcode: "80225",
+        }
+
+        profile.update(updated_attributes)
+
+        expect(profile.location).to have_attributes(updated_attributes)
+      end
+    end
+
+    context "when invalid" do
+      it "exposes errors from the Location" do
+        location = build(:location)
+        profile = Profile.new(user: location.user)
+
+        profile.update(address: nil)
+
+        expect(profile.errors).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/support/views.rb
+++ b/spec/support/views.rb
@@ -1,0 +1,15 @@
+module ViewStubHelpers
+  def signed_in=(signed_in)
+    @signed_in = signed_in
+  end
+
+  def signed_in?
+    @signed_in
+  end
+end
+
+RSpec.configure do |config|
+  config.before type: :view do
+    view.extend(ViewStubHelpers)
+  end
+end

--- a/spec/views/profiles/show.html.erb_spec.rb
+++ b/spec/views/profiles/show.html.erb_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "profiles/show" do
+  it "displays profile information" do
+    profile = double(
+      Profile,
+      address: "123 Fake St.",
+      email: "user@example.com",
+      name: "First Last",
+      notes: "On the porch",
+      zipcode: "90210",
+    )
+    assign(:profile, profile)
+
+    render
+
+    expect(rendered).to have_text(profile.address)
+    expect(rendered).to have_text(profile.email)
+    expect(rendered).to have_text(profile.name)
+    expect(rendered).to have_text(profile.notes)
+    expect(rendered).to have_text(profile.zipcode)
+  end
+
+  before do
+    view.signed_in = true
+  end
+end


### PR DESCRIPTION
https://trello.com/c/1TzjekfA

Add the ability to edit the Pickup location from the donor's Profile.

This commit introduces the `Profile` model which wraps a `User` and
their `Location`.