### PR TITLE
Display Welcome Modal upon registration

### DIFF
--- a/app/assets/stylesheets/_modal.scss
+++ b/app/assets/stylesheets/_modal.scss
@@ -8,10 +8,6 @@
     margin-bottom: 0;
   }
 
-  .modal-state {
-    display: none;
-  }
-
   .modal-fade-screen {
     // overlay
     @include position(fixed, 0 0 0 0);
@@ -57,7 +53,7 @@
     }
   }
 
-  .modal-state:checked + .modal-fade-screen {
+  #welcome:target + .modal-fade-screen {
     opacity: 1;
     visibility: visible;
   }

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -15,7 +15,7 @@ class RegistrationsController < ApplicationController
     if @registration.save
       sign_in(@registration.user)
 
-      redirect_to profile_url
+      redirect_to profile_url(anchor: :welcome)
     else
       render :new
     end

--- a/app/views/application/_welcome_modal.html.erb
+++ b/app/views/application/_welcome_modal.html.erb
@@ -1,5 +1,6 @@
 <div class="modal">
-  <input class="modal-state" id="modal-1" type="checkbox"  />
+  <div id="welcome"></div>
+
   <div class="modal-fade-screen">
     <div class="modal-inner content-container">
       <div class="modal-content">
@@ -20,8 +21,11 @@
           </li>
         </ol>
         <div class="modal-actions">
-          <div class="btn modal-confirm">Got It! Take me to my profile.</div>
+          <%= link_to "#", class: "btn modal-confirm" do %>
+            Got It! Take me to my profile.
+          <% end %>
         </div>
       </div>
     </div>
+  </div>
 </div>


### PR DESCRIPTION
Hide and show the Welcome modal based on the presence or absence of the
`#welcome` anchor in the URL.