### PR TITLE
Setup Heroku

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,7 +1,7 @@
 require_relative "production"
 
 Mail.register_interceptor(
-  RecipientInterceptor.new(ENV.fetch("EMAIL_RECIPIENTS"))
+  RecipientInterceptor.new(ENV.fetch("EMAIL_RECIPIENTS", "")),
 )
 
 Rails.application.configure do


### PR DESCRIPTION
This commit resolves missing environment variables from Heroku in
preparation for deploying to `staging` and `production`.

In addition to these code changes, the following commands were executed:

```bash
$  staging config:set SMTP_ADDRESS=garbage SMTP_DOMAIN=garbage SMTP_PASSWORD=garbage SMTP_USERNAME=garbage APPLICATION_HOST=freshfoodconnect-staging.herokuapp.com
$  production config:set SMTP_ADDRESS=garbage SMTP_DOMAIN=garbage SMTP_PASSWORD=garbage SMTP_USERNAME=garbage APPLICATION_HOST=freshfoodconnect-production.herokuapp.com
```

In the future (once we implement Email functionality), the
`SMTP_{ADDRESS,DOMAIN,PASSWORD,USERNAME}` values will need to be
corrected, and the `APPLICATION_HOST` should be configured to point to
the Fresh Food Connect domain.