### PR TITLE
Validate Zipcode Format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "sprockets", ">= 3.0.0"
 gem "sprockets-es6"
 gem "title"
 gem "uglifier"
+gem "validates_zipcode"
 
 group :development do
   gem "quiet_assets"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,8 @@ GEM
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
     uniform_notifier (1.9.0)
+    validates_zipcode (0.0.9)
+      activemodel (>= 3.2.0)
     web-console (3.1.1)
       activemodel (>= 4.2)
       debug_inspector
@@ -305,6 +307,7 @@ DEPENDENCIES
   timecop
   title
   uglifier
+  validates_zipcode
   web-console
   webmock
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -5,7 +5,7 @@ class Location < ActiveRecord::Base
 
   validates :address, presence: true
   validates :user, presence: true
-  validates :zipcode, presence: true
+  validates :zipcode, presence: true, zipcode: { country_code: :us }
 
   def supported?
     SUPPORTED_ZIPCODES.include?(zipcode)

--- a/app/models/pre_registration.rb
+++ b/app/models/pre_registration.rb
@@ -3,7 +3,7 @@ class PreRegistration
 
   attr_accessor :zipcode
 
-  validates :zipcode, presence: true
+  validates :zipcode, presence: true, zipcode: { country_code: :us }
 
   def supported?
     location.supported?

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,4 +1,4 @@
 class Subscription < ActiveRecord::Base
   validates :email, presence: true, uniqueness: { scope: :zipcode }, email: true
-  validates :zipcode, presence: true
+  validates :zipcode, presence: true, zipcode: { country_code: :us }
 end


### PR DESCRIPTION
Validate `zipcode` attributes format via the [validates_zipcode][gem]
gem.

Currently, the implementation assumes `country_code: :us`, but the gem
supports dynamic validation based on a `country_alpha2` database column
if the program is ever rolled out internationally.

[validates_zipcode]: https://github.com/dgilperez/validates_zipcode