### PR TITLE
Automatically Generate `ScheduledPickup` rows

### DIFF
--- a/app/helpers/scheduled_pickups_helper.rb
+++ b/app/helpers/scheduled_pickups_helper.rb
@@ -1,0 +1,14 @@
+module ScheduledPickupsHelper
+  def format_pickup_time(scheduled_pickup)
+    start_at = scheduled_pickup.start_at
+    end_at = scheduled_pickup.end_at
+    time_format = "%l:%M %P"
+
+    t(
+      "scheduled_pickups.format",
+      weekday: Date::DAYNAMES[start_at.wday],
+      start_at: start_at.strftime(time_format),
+      end_at: end_at.strftime(time_format),
+    )
+  end
+end

--- a/app/models/delivery_zone.rb
+++ b/app/models/delivery_zone.rb
@@ -5,10 +5,15 @@ class DeliveryZone < ActiveRecord::Base
     zipcode: { country_code: :us }
 
   has_many :locations, foreign_key: :zipcode, primary_key: :zipcode
+  has_many :scheduled_pickups
   has_many :users, through: :locations
 
   def self.supported?(zipcode)
     where(zipcode: zipcode).any?
+  end
+
+  def current_scheduled_pickup
+    scheduled_pickups.current.first
   end
 
   def to_param

--- a/app/models/pickup_scheduler.rb
+++ b/app/models/pickup_scheduler.rb
@@ -1,0 +1,50 @@
+class PickupScheduler
+  def initialize(delivery_zone)
+    @delivery_zone = delivery_zone
+  end
+
+  def schedule!
+    if current_scheduled_pickup.nil?
+      schedule_pickup!
+    end
+  end
+
+  private
+
+  attr_reader :delivery_zone
+
+  delegate(
+    :current_scheduled_pickup,
+    :end_hour,
+    :start_hour,
+    :weekday,
+    to: :delivery_zone,
+  )
+
+  def schedule_pickup!
+    delivery_zone.scheduled_pickups.create!(
+      start_at: start_time,
+      end_at: end_time,
+    )
+  end
+
+  def end_time
+    scheduled_date + end_hour.hours
+  end
+
+  def start_time
+    scheduled_date + start_hour.hours
+  end
+
+  def scheduled_date
+    start_of_week + offset_into_week
+  end
+
+  def offset_into_week
+    weekday.days
+  end
+
+  def start_of_week
+    Time.current.sunday.beginning_of_day
+  end
+end

--- a/app/models/scheduled_pickup.rb
+++ b/app/models/scheduled_pickup.rb
@@ -1,0 +1,11 @@
+class ScheduledPickup < ActiveRecord::Base
+  belongs_to :delivery_zone
+
+  validates :delivery_zone, presence: true
+  validates :end_at, presence: true
+  validates :start_at, presence: true
+
+  def self.current
+    where("start_at >= ?", Time.current.beginning_of_day)
+  end
+end

--- a/app/views/delivery_zones/show.html.erb
+++ b/app/views/delivery_zones/show.html.erb
@@ -7,8 +7,15 @@
   </header>
   <section class="zipcode-content-section">
     <h2 class="section-label">Scheduled Pickup Time</h2>
-    <span>Thusdays from 9:00am to 12:00am</span>
-    <a href="" class="edit-link">Edit</a>
+    <% if @delivery_zone.current_scheduled_pickup %>
+      <span><%= format_pickup_time(@delivery_zone.current_scheduled_pickup) %></span>
+
+      <a href="#" class="edit-link">
+        Edit
+      </a>
+    <% else %>
+      <span><%= t(".no_pickup") %></span>
+    <% end %>
   </section>
   <section class="zipcode-content-section">
     <h2 class="section-label">Suppliers</h2>

--- a/bin/setup
+++ b/bin/setup
@@ -11,7 +11,7 @@ gem install bundler --conservative
 bundle check || bundle install
 
 # Set up database and add any development seed data
-bin/rake dev:prime
+bin/rake dev:prime pickups:schedule
 
 # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
 mkdir -p .git/safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,8 @@ en:
       suppliers:
         one: "%{count} Supplier"
         other: "%{count} Suppliers"
+    show:
+      no_pickup: "There are no pickups scheduled for this week."
 
   marketing:
     index:
@@ -37,6 +39,9 @@ en:
   profiles:
     show:
       edit: "Edit Profile"
+
+  scheduled_pickups:
+    format: "%{weekday} from %{start_at} to %{end_at}"
 
   registrations:
     new:

--- a/db/migrate/20160405152728_create_scheduled_pickups.rb
+++ b/db/migrate/20160405152728_create_scheduled_pickups.rb
@@ -1,0 +1,11 @@
+class CreateScheduledPickups < ActiveRecord::Migration
+  def change
+    create_table :scheduled_pickups do |t|
+      t.belongs_to :delivery_zone, null: false
+      t.datetime :start_at, null: false
+      t.datetime :end_at, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160405191126_add_time_range_to_delivery_zones.rb
+++ b/db/migrate/20160405191126_add_time_range_to_delivery_zones.rb
@@ -1,0 +1,7 @@
+class AddTimeRangeToDeliveryZones < ActiveRecord::Migration
+  def change
+    add_column :delivery_zones, :start_hour, :integer, null: false, default: 0
+    add_column :delivery_zones, :end_hour, :integer, null: false, default: 0
+    add_column :delivery_zones, :weekday, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160401222800) do
+ActiveRecord::Schema.define(version: 20160405191126) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,18 +33,31 @@ ActiveRecord::Schema.define(version: 20160401222800) do
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "delivery_zones", force: :cascade do |t|
-    t.string   "zipcode",    null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "zipcode",                null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.integer  "start_hour", default: 0, null: false
+    t.integer  "end_hour",   default: 0, null: false
+    t.integer  "weekday",    default: 0, null: false
   end
 
   add_index "delivery_zones", ["zipcode"], name: "index_delivery_zones_on_zipcode", unique: true, using: :btree
 
   create_table "locations", force: :cascade do |t|
-    t.string  "address",              null: false
-    t.string  "zipcode",              null: false
-    t.text    "notes",   default: "", null: false
-    t.integer "user_id",              null: false
+    t.string  "address",                                          null: false
+    t.string  "zipcode",                                          null: false
+    t.text    "notes",                               default: "", null: false
+    t.integer "user_id",                                          null: false
+    t.decimal "latitude",  precision: 15, scale: 10
+    t.decimal "longitude", precision: 15, scale: 10
+  end
+
+  create_table "scheduled_pickups", force: :cascade do |t|
+    t.integer  "delivery_zone_id", null: false
+    t.datetime "start_at",         null: false
+    t.datetime "end_at",           null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
   end
 
   create_table "subscriptions", force: :cascade do |t|

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -13,6 +13,14 @@ if Rails.env.development? || Rails.env.test?
         email: "user@example.com",
         password: "password",
       )
+
+      create(
+        :delivery_zone,
+        zipcode: "80225",
+        start_hour: 13,
+        end_hour: 15,
+        weekday: Date::DAYNAMES.index("Thursday"),
+      )
     end
   end
 end

--- a/lib/tasks/pickups.rake
+++ b/lib/tasks/pickups.rake
@@ -1,0 +1,8 @@
+namespace :pickups do
+  desc "Schedule upcoming pickups"
+  task schedule: :environment do
+    DeliveryZone.all.each do |delivery_zone|
+      PickupScheduler.new(delivery_zone).schedule!
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,7 +3,17 @@ FactoryGirl.define do
   sequence(:zipcode) { |i| i.to_s.rjust(5, "0") }
 
   factory :delivery_zone do
+    start_hour 0
+    end_hour 0
+    weekday 0
+
     zipcode
+
+    trait :with_scheduled_pickups do
+      after(:create) do |delivery_zone|
+        PickupScheduler.new(delivery_zone).schedule!
+      end
+    end
   end
 
   factory :location do
@@ -27,6 +37,13 @@ FactoryGirl.define do
     password "password"
 
     email
+  end
+
+  factory :scheduled_pickup do
+    start_at { Time.current - 1.hour }
+    end_at { Time.current + 1.hour }
+
+    delivery_zone
   end
 
   factory :user do

--- a/spec/features/admin_views_pickup_times_spec.rb
+++ b/spec/features/admin_views_pickup_times_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require "rake"
+
+feature "Admin views pickup time", :rake do
+  scenario "generated weekly" do
+    delivery_zone = create(
+      :delivery_zone,
+      start_hour: 13,
+      end_hour: 15,
+      weekday: wednesday,
+    )
+    schedule_pickups!
+
+    view_delivery_zone(delivery_zone)
+
+    expect(page).to have_text("Wednesday from 1:00 pm to 3:00 pm")
+  end
+
+  def wednesday
+    Date::WEEKDAYS["wednesday"]
+  end
+
+  def view_delivery_zone(delivery_zone)
+    visit root_path(as: create(:user, :admin))
+    click_on delivery_zone.zipcode
+  end
+
+  def schedule_pickups!
+    Rake::Task["pickups:schedule"].invoke
+  end
+
+  before :all do
+    Rake.application.rake_require "tasks/pickups"
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/models/delivery_zone_spec.rb
+++ b/spec/models/delivery_zone_spec.rb
@@ -4,11 +4,30 @@ describe DeliveryZone do
   it { should validate_presence_of(:zipcode) }
 
   it { should have_many(:locations) }
+  it { should have_many(:scheduled_pickups) }
   it { should have_many(:users).through(:locations) }
 
   context "uniqueness" do
     subject { build(:delivery_zone) }
 
     it { should validate_uniqueness_of(:zipcode).case_insensitive }
+  end
+
+  describe "#current_scheduled_pickup", :rake do
+    it "returns the current ScheduledPickup" do
+      delivery_zone = create(
+        :delivery_zone,
+        :with_scheduled_pickups,
+        start_hour: 0,
+        end_hour: 1,
+        weekday: 0,
+      )
+
+      current_scheduled_pickup = delivery_zone.current_scheduled_pickup
+
+      expect(current_scheduled_pickup.start_at.hour).to eq(0)
+      expect(current_scheduled_pickup.end_at.hour).to eq(1)
+      expect(current_scheduled_pickup.start_at.wday).to eq(0)
+    end
   end
 end

--- a/spec/models/pickup_scheduler_spec.rb
+++ b/spec/models/pickup_scheduler_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+describe PickupScheduler do
+  context "when there are no pickups scheduled for the current week" do
+    it "creates a ScheduledPickup" do
+      beginning_of_week = Time.current.sunday.beginning_of_day
+
+      Timecop.freeze(beginning_of_week) do
+        delivery_zone = create(
+          :delivery_zone,
+          start_hour: 0,
+          end_hour: 1,
+          weekday: beginning_of_week.wday,
+        )
+        create(
+          :scheduled_pickup,
+          delivery_zone: delivery_zone,
+          start_at: beginning_of_week - 1.day,
+          end_at: beginning_of_week - 1.day,
+        )
+        scheduler = PickupScheduler.new(delivery_zone)
+
+        scheduler.schedule!
+        scheduled_pickup = ScheduledPickup.last
+
+        expect(ScheduledPickup.count).to eq(2)
+        expect(scheduled_pickup.start_at.hour).to eq(0)
+        expect(scheduled_pickup.end_at.hour).to eq(1)
+        expect(scheduled_pickup.start_at.wday).to eq(0)
+      end
+    end
+  end
+
+  context "when there is already a Pickup scheduled for the week" do
+    it "doesn't create a ScheduledPickup" do
+      beginning_of_week = Time.current.sunday.beginning_of_day
+
+      Timecop.freeze(beginning_of_week) do
+        delivery_zone = create(
+          :delivery_zone,
+          weekday: beginning_of_week.wday,
+        )
+        create(
+          :scheduled_pickup,
+          delivery_zone: delivery_zone,
+          start_at: beginning_of_week + 1.hour,
+          end_at: beginning_of_week + 2.hours,
+        )
+        scheduler = PickupScheduler.new(delivery_zone)
+
+        scheduler.schedule!
+
+        expect(ScheduledPickup.count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/models/scheduled_pickup_spec.rb
+++ b/spec/models/scheduled_pickup_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe ScheduledPickup do
+  it { should belong_to(:delivery_zone) }
+
+  it { should validate_presence_of(:delivery_zone) }
+  it { should validate_presence_of(:end_at) }
+  it { should validate_presence_of(:start_at) }
+
+  describe ".current" do
+    it "includes scheduled pickups from today and onward" do
+      _yesterday_at_noon = create_scheduled_pickup(yesterday + 12.hours)
+      today_at_noon = create_scheduled_pickup(today + 12.hours)
+      tomorrow_at_noon = create_scheduled_pickup(tomorrow + 12.hours)
+
+      current = ScheduledPickup.current
+
+      expect(current).to match_array([today_at_noon, tomorrow_at_noon])
+    end
+
+    def create_scheduled_pickup(start_at)
+      create(:scheduled_pickup, start_at: start_at, end_at: start_at + 1.hour)
+    end
+
+    def today
+      Time.current.beginning_of_day
+    end
+
+    def tomorrow
+      today + 1.day
+    end
+
+    def yesterday
+      today - 1.day
+    end
+  end
+end

--- a/spec/views/delivery_zones/show.html.erb_spec.rb
+++ b/spec/views/delivery_zones/show.html.erb_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+describe "delivery_zones/show" do
+  it "displays the Delivery Zone" do
+    current_scheduled_pickup = build_scheduled_pickup(
+      start_at: now + 1.hour,
+      end_at: now + 2.hours,
+    )
+    delivery_zone = build_delivery_zone(
+      zipcode: "90210",
+      current_scheduled_pickup: current_scheduled_pickup,
+    )
+    assign(:delivery_zone, delivery_zone)
+
+    render
+
+    expect(rendered).to have_text(delivery_zone.zipcode)
+    expect(rendered).to have_text("1:00 am")
+    expect(rendered).to have_text("2:00 am")
+  end
+
+  context "when there isn't a pickup scheduled" do
+    it "mentions that there isn't a pickup" do
+      delivery_zone = build_delivery_zone
+      assign(:delivery_zone, delivery_zone)
+
+      render
+
+      expect(rendered).to have_text(t("delivery_zones.show.no_pickup"))
+    end
+  end
+
+  def build_scheduled_pickup(**options)
+    double(ScheduledPickup, options)
+  end
+
+  def build_delivery_zone(**options)
+    attributes = attributes_for(:delivery_zone).
+      merge(options).
+      reverse_merge(
+        users: [],
+        current_scheduled_pickup: nil,
+      )
+
+    double(DeliveryZone, attributes)
+  end
+
+  let(:now) { Date.new(2016, 4, 5).beginning_of_day }
+
+  before do
+    view.signed_in = true
+  end
+
+  around do |example|
+    Timecop.freeze(now) { example.run }
+  end
+end


### PR DESCRIPTION
https://trello.com/c/vWs6DoOg

This commit exposes the `pickups:schedule` Rake task to idempotently
create instances of `ScheduledPickup` associated with all active
Delivery Zones.

Currently, the implementation assumes that each Delivery Zone know when
its pickups are typically scheduled for. When creating pickup timeslots,
the scheduler will infer time ranges and days from the Zone.

Future commits will allow administrators to both create and modify
existing pickup schedules, as well as modify when pickups occur in a
zone.