### PR TITLE
Link to Marketing Page from Sign In page

### DIFF
--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -16,11 +16,8 @@
       <%= form.submit %>
     </div>
 
-    <div class="other-links">
-      <% if Clearance.configuration.allow_sign_up? %>
-        <%= link_to t(".sign_up"), sign_up_path %>
-      <% end %>
-      <%= link_to t(".forgot_password"), new_password_path %>
-    </div>
+  <div class="other-links">
+    <%= link_to t(".sign_up"), root_path %>
+    <%= link_to t(".forgot_password"), new_password_path %>
   </div>
 <% end %>

--- a/config/locales/clearance.en.yml
+++ b/config/locales/clearance.en.yml
@@ -46,7 +46,7 @@ en:
   sessions:
     form:
       forgot_password: Forgot password?
-      sign_up: Sign up
+      sign_up: Not registered?
     new:
       title: Sign in
   users:


### PR DESCRIPTION
As a guest user, if I'm linked to an authenticated URL and aren't
signed in, I'd need a link to get to the marketing page so that I can
complete the registration flow.
