### PR TITLE
Fix `dev:prime` seed data

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -72,7 +72,7 @@ class Registration
 
   def zipcode_is_supported
     unless zipcode.blank? || DeliveryZone.supported?(zipcode)
-      errors[:zipcode] = I18n.t(".unsupported", zipcode: zipcode)
+      errors[:zipcode] = I18n.t("validations.unsupported", zipcode: zipcode)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,3 +106,6 @@ en:
 
   titles:
     application: Fresh Food Connect
+
+  validations:
+    unsupported: "We're sorry, our service is not available in %{zipcode} at this time."

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -6,21 +6,21 @@ if Rails.env.development? || Rails.env.test?
     task prime: "db:setup" do
       include FactoryGirl::Syntax::Methods
 
-      create(
-        :user,
-        :admin,
-        name: "Super User",
-        email: "user@example.com",
-        password: "password",
-      )
-
-      create(
+      delivery_zone = create(
         :delivery_zone,
         zipcode: "80205",
         start_hour: 13,
         end_hour: 15,
         weekday: Date::DAYNAMES.index("Thursday"),
       )
+      registration = create(
+        :registration,
+        name: "Super User",
+        email: "user@example.com",
+        password: "password",
+        zipcode: delivery_zone.zipcode,
+      )
+      registration.user.update!(admin: true)
     end
   end
 end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -18,7 +18,8 @@ describe Registration do
           valid?: false,
           invalid?: true,
         )
-        expect(registration.errors[:zipcode]).not_to be_empty
+        expect(registration.errors[:zipcode]).
+          to eq([t("validations.unsupported", zipcode: registration.zipcode)])
       end
     end
 


### PR DESCRIPTION
https://trello.com/c/eRcgsKzE

Most users coming into the system will go through the normal
registration flow, which guards against User's not having locations.

This commit changes `dev:prime` to create a User through a Registration
factory.

Additionally, it corrects and covers a bug that was discovered during
the process.