### PR TITLE
Determine Donation status based on latest change

### DIFF
--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -17,11 +17,27 @@ class Donation < ActiveRecord::Base
     joins(:scheduled_pickup).merge(ScheduledPickup.current)
   end
 
+  def declined?
+    declined_at.present? &&
+      time_or_epoch(declined_at) > time_or_epoch(confirmed_at)
+  end
+
+  def confirmed?
+    confirmed_at.present? &&
+      time_or_epoch(confirmed_at) >= time_or_epoch(declined_at)
+  end
+
   def pickup_date
     scheduled_pickup.start_at.to_date
   end
 
   def pending?
     ! (confirmed || declined)
+  end
+
+  private
+
+  def time_or_epoch(timestamp)
+    timestamp.presence || Time.at(0)
   end
 end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -29,6 +29,106 @@ describe Donation do
     end
   end
 
+  describe "#confirmed?" do
+    context "when confirmed_at is falsy" do
+      it "returns false" do
+        donation = Donation.new(confirmed_at: nil)
+
+        confirmed = donation.confirmed?
+
+        expect(confirmed).to be false
+      end
+    end
+
+    context "when the Donation has been confirmed" do
+      context "and not yet declined" do
+        it "returns true" do
+          donation = Donation.new(declined_at: nil, confirmed: true)
+
+          confirmed = donation.confirmed?
+
+          expect(confirmed).to be true
+        end
+      end
+
+      context "and then declined" do
+        it "returns false" do
+          donation = Donation.new(
+            confirmed_at: 1.minute.ago,
+            declined_at: Time.current,
+          )
+
+          confirmed = donation.confirmed?
+
+          expect(confirmed).to be false
+        end
+      end
+
+      context "after being previously declined" do
+        it "returns true" do
+          donation = Donation.new(
+            declined_at: 1.minute.ago,
+            confirmed_at: Time.current,
+          )
+
+          confirmed = donation.confirmed?
+
+          expect(confirmed).to be true
+        end
+      end
+    end
+  end
+
+  describe "#declined?" do
+    context "when declined_at is falsy" do
+      it "returns false" do
+        donation = Donation.new(declined_at: nil)
+
+        declined = donation.declined?
+
+        expect(declined).to be false
+      end
+    end
+
+    context "when the Donation has been declined" do
+      context "and not yet confirmed" do
+        it "returns true" do
+          donation = Donation.new(confirmed_at: nil, declined: true)
+
+          declined = donation.declined?
+
+          expect(declined).to be true
+        end
+      end
+
+      context "and then confirmed" do
+        it "returns false" do
+          donation = Donation.new(
+            declined_at: 1.minute.ago,
+            confirmed_at: Time.current,
+          )
+
+          declined = donation.declined?
+
+          expect(declined).to be false
+        end
+      end
+
+      context "after being previously confirmed" do
+        it "returns true" do
+          donation = Donation.new(
+            confirmed_at: 1.minute.ago,
+            declined_at: Time.current,
+          )
+
+          declined = donation.declined?
+
+          expect(declined).to be true
+        end
+      end
+    end
+  end
+
   describe "#pending?" do
     context "when the donation has been confirmed" do
       it "returns false" do


### PR DESCRIPTION
A donation can be both confirmed and declined.

Instead of blanking the opposing column whenever an action is taken, we
can preserve the timestamp of each action and determine current status
based on the latest action taken.

For example, if a donation is first confirmed, then declined, the
current status should reflect that it was declined at the timestamp the
action occurred, as well as maintain the timestamp that it was initally
confirmed at (for history's sake).

The reverse is also true.


This commit achieves this by overriding the `#*?` methods created by
`time_for_a_boolean` while still leveraging the rest of what that gem
has to offer.