### PR TITLE
Extract `/donations/:id/edit` page

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -6,7 +6,7 @@ class ConfirmationsController < ApplicationController
 
     flash[:success] = t(".success")
 
-    redirect_to :back
+    redirect_to edit_donation_url(@confirmation.donation)
   end
 
   def update

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -1,0 +1,5 @@
+class DonationsController < ApplicationController
+  def edit
+    @donation = current_user.donations.find(params[:id])
+  end
+end

--- a/app/models/confirmation.rb
+++ b/app/models/confirmation.rb
@@ -12,9 +12,9 @@ class Confirmation
     donation.update!(declined: true)
   end
 
-  private
-
   attr_reader :donation
+
+  private
 
   def schedule_notification_email!
     DonationReminderJob.

--- a/app/views/donations/_current.html.erb
+++ b/app/views/donations/_current.html.erb
@@ -13,26 +13,17 @@
           date: l(donation.pickup_date, format: :default),
         ) %></dt>
         <dd class="donation-status pending">
-          <% if donation.confirmed? %>
-            <%= t(".status.confirmed") %>
-          <% elsif donation.declined? %>
-            <%= t(".status.declined") %>
-          <% else %>
-            <%= button_to(donation_confirmation_path(donation), method: :post) do %>
-              <%= t(".confirm") %>
-            <% end %>
-            <%= button_to(donation_confirmation_path(donation), method: :delete) do %>
-              <%= t(".decline") %>
-            <% end %>
+          <%= render("donations/status", donation: donation) %>
+
+          <%= link_to edit_donation_url(donation) do %>
+            <%= t(".edit") %>
           <% end %>
         </dd>
       </div>
-      <% if donation.confirmed? %>
-        <div class="dl-group">
-          <dt><%= t(".size") %></dt>
-          <dd><%= render("donations/sizes", donation: donation) %></dd>
-        </div>
-      <% end %>
+      <div class="dl-group">
+        <dt><%= t(".size") %></dt>
+        <dd><%= t("donations.sizes.#{donation.size}") %></dd>
+      </div>
       <div class="dl-group">
         <dt><%= t(".notes") %></dt>
         <dd><%= donation.notes %></dd>

--- a/app/views/donations/_status.html.erb
+++ b/app/views/donations/_status.html.erb
@@ -1,0 +1,13 @@
+<% if donation.confirmed? %>
+  <%= t(".confirmed") %>
+<% elsif donation.declined? %>
+  <%= t(".declined") %>
+<% else %>
+  <%= button_to(donation_confirmation_path(donation), method: :post) do %>
+    <%= t(".confirm") %>
+  <% end %>
+
+  <%= button_to(donation_confirmation_path(donation), method: :delete) do %>
+    <%= t(".decline") %>
+  <% end %>
+<% end %>

--- a/app/views/donations/edit.html.erb
+++ b/app/views/donations/edit.html.erb
@@ -1,0 +1,3 @@
+<%= render("donations/status", donation: @donation) %>
+
+<%= render("donations/sizes", donation: @donation) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,21 +48,22 @@ en:
 
   donations:
     current:
+      edit: "Change my donation"
       header: "Pickup Info"
-      pickup_time: "Scheduled Pickup Time"
-      notes: "Pickup Notes (e.g. On the table on the front porch)"
-      confirm: "Yes, I will be making a donation this week."
-      decline: "No, I will not be making a donation this week."
       none: "There are no pickups scheduled for this week."
+      notes: "Pickup Notes (e.g. On the table on the front porch)"
+      pickup_time: "Scheduled Pickup Time"
       size: "Donation Size"
-      status:
-        confirmed: "Confirmed"
-        declined: "Declined"
       status_html: Donation Status for <span class="next-pickup-date">%{date}</span>
     sizes:
       small: "Small"
       medium: "Medium"
       large: "Large"
+    status:
+      confirm: "Yes, I will be making a donation this week."
+      confirmed: "Confirmed"
+      decline: "No, I will not be making a donation this week."
+      declined: "Declined"
 
   marketing:
     index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   resource :profile, only: [:show, :edit, :update]
 
-  resources :donations, only: [] do
+  resources :donations, only: [:edit] do
     resource :confirmation, only: [:create, :destroy, :update]
   end
   resources :pre_registrations, only: [:create]

--- a/spec/features/donor_confirms_donation_spec.rb
+++ b/spec/features/donor_confirms_donation_spec.rb
@@ -13,35 +13,48 @@ feature "Donor confirms donation" do
     end
     last_donation = Donation.last
 
-    expect(last_donation).to have_attributes(
-      confirmed?: true,
-      declined?: false,
-      pending?: false,
-    )
-    expect(last_donation.donor).to have_attributes(
-      email: email,
-    )
-    expect(page).to have_success_flash
+    expect(last_donation.donor).to belong_to(email)
+    expect(sent_emails.last).to be_sent_to(email)
+    expect(last_donation).to be_confirmed
+    expect(page).to have_confirmation_flash
     expect(page).to have_confirmed_status
-    expect(sent_emails.last).to have_attributes(
-      to: [email],
-    )
+    expect(page).to have_size_options
   end
 
   def sent_emails
     ActionMailer::Base.deliveries
   end
 
-  def have_success_flash
+  def have_size_options
+    have_text t("donations.sizes.medium")
+  end
+
+  def have_confirmation_flash
     have_text t("confirmations.create.success")
   end
 
   def have_confirmed_status
-    have_text t("donations.current.status.confirmed")
+    have_text t("donations.status.confirmed")
+  end
+
+  def be_sent_to(email)
+    have_attributes(to: [email])
+  end
+
+  def belong_to(email)
+    have_attributes(email: email)
+  end
+
+  def be_confirmed
+    have_attributes(
+      confirmed?: true,
+      declined?: false,
+      pending?: false,
+    )
   end
 
   def confirm_donation
-    click_on t("donations.current.confirm")
+    click_on t("donations.status.confirm")
   end
 
   def sign_up_donor(zipcode:, email:)

--- a/spec/features/donor_describes_donation_spec.rb
+++ b/spec/features/donor_describes_donation_spec.rb
@@ -16,10 +16,11 @@ feature "Donor describes donation" do
   end
 
   def have_selected_size(size)
-    have_css("[disabled]", text: size_i18n(size))
+    have_text size_i18n(size)
   end
 
   def pick_donation_size(size)
+    click_on t("donations.current.edit")
     click_on size_i18n(size)
   end
 


### PR DESCRIPTION
Implements a form for users to modify their donation.

Currently, users are linked from their `/profile` page, but in future
commits they will be able to jump directly to the form from a Pickup
notification email.