### PR TITLE
Improve `/subscriptions/new` copy

### DIFF
--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -1,7 +1,7 @@
 <section class="no-service-message">
   <div class="content-wrapper-narrow form-container">
     <header class="form-container__header">
-      <h3>We're sorry, our service is not available in your area at this time.</h3>
+      <h3><%= t(".header") %></h3>
     </header>
 
     <%= render "subscriptions/form", subscription: @subscription %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,7 +121,9 @@ en:
   subscriptions:
     form:
       prompt: "But there's good news! If you'd like to provide us with your email, we will notify you once we begin service in your area:"
-      decline: "No thanks"
+      decline: "No thanks, take me back to the homepage."
+    new:
+      header: "We're sorry, our service is not available in your area at this time."
 
   time:
     formats:


### PR DESCRIPTION
https://trello.com/c/TSEipEHK

This commit improves the user-facing copy around declining to subscribe
for roll-out notifications.

Additionally, it internationalizes the `/subscriptions/new` page.