### PR TITLE
Redirect to `/profile` when a donation is declined

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -26,7 +26,7 @@ class ConfirmationsController < ApplicationController
 
     flash[:success] = t(".success")
 
-    redirect_to :back
+    redirect_to profile_url
   end
 
   private

--- a/spec/features/donor_declines_donation_spec.rb
+++ b/spec/features/donor_declines_donation_spec.rb
@@ -13,6 +13,11 @@ feature "Donor declines donation" do
     expect(last_donation.donor).to belong_to(email)
     expect(page).to have_success_flash
     expect(page).to have_declined_status
+    expect(page).to be_redirected_to_profile
+  end
+
+  def be_redirected_to_profile
+    have_text t("profiles.show.edit")
   end
 
   def belong_to(email)


### PR DESCRIPTION
If a donation is declined, there is no need to present the user with an
option to edit the declined donation.