### PR TITLE
Extract partials

### DIFF
--- a/app/helpers/donations_helper.rb
+++ b/app/helpers/donations_helper.rb
@@ -10,6 +10,6 @@ module DonationsHelper
   end
 
   def label_for_donation(donation)
-    t("donations.status.#{status_for_donation(donation)}")
+    t("donations.statuses.#{status_for_donation(donation)}")
   end
 end

--- a/app/helpers/donations_helper.rb
+++ b/app/helpers/donations_helper.rb
@@ -12,4 +12,8 @@ module DonationsHelper
   def label_for_donation(donation)
     t("donations.statuses.#{status_for_donation(donation)}")
   end
+
+  def render_donation_status(donation, &block)
+    render(layout: "donations/status", locals: { donation: donation }, &block)
+  end
 end

--- a/app/views/donations/_actions.html.erb
+++ b/app/views/donations/_actions.html.erb
@@ -1,0 +1,4 @@
+<div class="btn-container">
+  <%= render("donations/confirm", donation: donation) %>
+  <%= render("donations/decline", donation: donation) %>
+</div>

--- a/app/views/donations/_donation.html.erb
+++ b/app/views/donations/_donation.html.erb
@@ -1,12 +1,5 @@
 <div class="dl-group">
-  <dl>
-    <dt>
-      <%= t(".pickup_time") %>
-    </dt>
-    <dd>
-      <%= format_pickup_time(donation.scheduled_pickup) %>
-    </dd>
-  </dl>
+  <%= render(donation.scheduled_pickup) %>
 </div>
 
 <div class="dl-group">

--- a/app/views/donations/_donation.html.erb
+++ b/app/views/donations/_donation.html.erb
@@ -3,28 +3,11 @@
 </div>
 
 <div class="dl-group">
-  <dl>
-    <dt>
-      <%= t(
-        ".status_html",
-        date: l(donation.pickup_date, format: :default),
-      ) %>
-    </dt>
-
-    <% if donation.pending? %>
-      <dd class="btn-container">
-        <%= render("donations/confirm", donation: donation) %>
-        <%= render("donations/decline", donation: donation) %>
-      </dd>
-    <% else %>
-      <dd>
-        <%= label_for_donation(donation) %>
-        <%= link_to edit_donation_path(donation), class: "edit-donation" do %>
-          <%= t(".edit") %>
-        <% end %>
-      </dd>
+  <%= render_donation_status(donation) do %>
+    <%= link_to edit_donation_path(donation), class: "edit-donation" do %>
+      <%= t("donations.donation.edit") %>
     <% end %>
-  </dl>
+  <% end %>
 </div>
 
 <% if donation.confirmed? %>

--- a/app/views/donations/_status.html.erb
+++ b/app/views/donations/_status.html.erb
@@ -1,7 +1,17 @@
-<% if donation.confirmed? || donation.declined? %>
-  <%= label_for_donation(donation) %>
-<% else %>
-  <%= render("donations/confirm", donation: donation) %>
+<dl>
+  <dt>
+    <%= t(
+      ".html",
+      date: l(donation.pickup_date, format: :default),
+    ) %>
+  </dt>
+  <% if donation.pending? %>
+    <%= render("donations/actions", donation: donation) %>
+  <% else %>
+    <dd class="donation-status--<%= status_for_donation(donation) %>">
+      <%= label_for_donation(donation) %>
 
-  <%= render("donations/decline", donation: donation) %>
-<% end %>
+      <%= yield %>
+    </dd>
+  <% end %>
+</dl>

--- a/app/views/donations/_status.html.erb
+++ b/app/views/donations/_status.html.erb
@@ -1,7 +1,5 @@
-<% if donation.confirmed? %>
-  <%= t(".confirmed") %>
-<% elsif donation.declined? %>
-  <%= t(".declined") %>
+<% if donation.confirmed? || donation.declined? %>
+  <%= label_for_donation(donation) %>
 <% else %>
   <%= render("donations/confirm", donation: donation) %>
 

--- a/app/views/scheduled_pickups/_scheduled_pickup.html.erb
+++ b/app/views/scheduled_pickups/_scheduled_pickup.html.erb
@@ -1,0 +1,8 @@
+<dl>
+  <dt>
+    <%= t(".header") %>
+  </dt>
+  <dd>
+    <%= format_pickup_time(scheduled_pickup) %>
+  </dd>
+</dl>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,13 +60,14 @@ en:
       text: "Donating"
     donation:
       edit: "Change my Donation"
-      status_html: Donation Status for <span class="next-pickup-date">%{date}</span>
     decline:
       text: "Not Donating"
     sizes:
       small: "Small"
       medium: "Medium"
       large: "Large"
+    status:
+      html: Donation Status for <span class="next-pickup-date">%{date}</span>
     statuses:
       confirmed: "Confirmed"
       declined: "Declined"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -68,7 +68,7 @@ en:
       small: "Small"
       medium: "Medium"
       large: "Large"
-    status:
+    statuses:
       confirmed: "Confirmed"
       declined: "Declined"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,7 +60,6 @@ en:
       text: "Donating"
     donation:
       edit: "Change my Donation"
-      pickup_time: "Scheduled Pickup Time"
       status_html: Donation Status for <span class="next-pickup-date">%{date}</span>
     decline:
       text: "Not Donating"
@@ -102,6 +101,8 @@ en:
     new:
       header: "Schedule the next pickup"
       prompt: "Be sure to include the earliest and latest pickup times."
+    scheduled_pickup:
+      header: "Scheduled Pickup Time"
     show:
       edit: "Edit"
     update:

--- a/spec/features/donor_confirms_donation_spec.rb
+++ b/spec/features/donor_confirms_donation_spec.rb
@@ -25,7 +25,7 @@ feature "Donor confirms donation" do
   end
 
   def have_confirmed_status
-    have_text t("donations.status.confirmed")
+    have_text t("donations.statuses.confirmed")
   end
 
   def be_sent_to(email)

--- a/spec/features/donor_declines_donation_spec.rb
+++ b/spec/features/donor_declines_donation_spec.rb
@@ -37,7 +37,7 @@ feature "Donor declines donation" do
   end
 
   def have_declined_status
-    have_text t("donations.status.declined")
+    have_text t("donations.statuses.declined")
   end
 
   def decline_donation


### PR DESCRIPTION
**Move Status Label namespace to `donations.statuses`**

Currently, `donations/status` is a partial, which means it should own
the `donations.status` namespace.

Unfortunately, `label_for_donation` depends on `donations.status` to
enumerate the translations for a given status.

To prevent this collision, this commit moves the status label
internationalization to the `donations.statuses` namespace.

**Extract `scheduled_pickups/scheduled_pickup`**

This commit introduces a partial that encapsulates rendering a Scheduled
Pickup.

**Extract the `donations/actions` partial**

Since `donations/confirm` and `donations/decline` are usually coupled,
this commit extracts the `donations/actions` partial to maximize future
re-use.

**Extract the `donations/status` layout**

This commit introduces the `donations/status` partial to be used as a
layout that yields a block.

The partial is responsible for showing the internationalized status for
the donation.

Since rendering partials as layouts has a verbose syntax, this commit
also introduces the `render_donation_status` helper to encapsulate the
magic incantation to correctly render a partial with a block.