### PR TITLE
Add notes to profile sidebar

### DIFF
--- a/app/assets/images/info.svg
+++ b/app/assets/images/info.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
+<g id="Info_2_x2C__About_2">
+	<path d="M8,0C3.582,0,0,3.582,0,8s3.582,8,8,8s8-3.582,8-8S12.418,0,8,0z M8,14c-3.309,0-6-2.692-6-6s2.691-6,6-6
+		c3.308,0,6,2.692,6,6S11.308,14,8,14z"/>
+	<path d="M8.5,4h-1C7.224,4,7,4.224,7,4.5v1C7,5.776,7.224,6,7.5,6h1C8.776,6,9,5.776,9,5.5v-1C9,4.224,8.776,4,8.5,4z"/>
+	<path d="M8.5,7h-1C7.224,7,7,7.224,7,7.5v4C7,11.776,7.224,12,7.5,12h1C8.776,12,9,11.776,9,11.5v-4C9,7.224,8.776,7,8.5,7z"/>
+</svg>

--- a/app/assets/stylesheets/_global.scss
+++ b/app/assets/stylesheets/_global.scss
@@ -43,8 +43,8 @@ body {
   width: 100%;
 
   @include media($medium-screen-up) {
-    @include span-columns(8 of 12);
-    @include shift(2 of 12);
+    @include span-columns(9 of 12);
+    @include shift(1.5 of 12);
   }
 }
 

--- a/app/assets/stylesheets/_profile.scss
+++ b/app/assets/stylesheets/_profile.scss
@@ -56,7 +56,7 @@
   width: 100%;
 
   @include media($large-screen-up) {
-    @include span-columns(2.5 of 8);
+    @include span-columns(3 of 9);
     margin: $base-spacing 0 0;
   }
 
@@ -73,7 +73,7 @@
 
   &__metadata {
     display: block;
-
+    padding-right: $small-spacing;
   }
 
   .edit {
@@ -87,7 +87,7 @@
   width: 100%;
 
   @include media($large-screen-up) {
-    @include span-columns(5.5 of 8);
+    @include span-columns(6 of 9);
   }
 }
 

--- a/app/views/profiles/_profile.html.erb
+++ b/app/views/profiles/_profile.html.erb
@@ -11,3 +11,7 @@
   <%= inline_svg("map.svg", class: "svg-icon") %>
   <%= profile.zipcode %>
 </span>
+<span class="supplier-info__metadata notes">
+  <%= inline_svg("info.svg", class: "svg-icon") %>
+  These are some notes. They shouldn't be too long, so maybe we can set a character limit of 100 characters or so.
+</span>


### PR DESCRIPTION
* Add svg icon for notes
* Add a space for notes in the profile sidebar
* Increase width of profile layout to accomodate for additional text (notes in sidebar)

<img width="920" alt="screen shot 2016-04-13 at 11 38 42 am" src="https://cloud.githubusercontent.com/assets/5934188/14503240/6a6c73f6-016c-11e6-9026-3cdf7f48ccca.png">
