### PR TITLE
Transform `Confirmation` into a `SimpleDelegator`

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -32,7 +32,7 @@ class ConfirmationsController < ApplicationController
   private
 
   def build_confirmation
-    Confirmation.new(donation: find_donation)
+    Confirmation.new(find_donation)
   end
 
   def find_donation

--- a/app/helpers/scheduled_pickups_helper.rb
+++ b/app/helpers/scheduled_pickups_helper.rb
@@ -1,8 +1,0 @@
-module ScheduledPickupsHelper
-  def format_pickup_time(scheduled_pickup)
-    TimeRange.new(
-      start_at: scheduled_pickup.start_at,
-      end_at: scheduled_pickup.end_at,
-    )
-  end
-end

--- a/app/models/confirmation.rb
+++ b/app/models/confirmation.rb
@@ -1,15 +1,17 @@
-class Confirmation
-  def initialize(donation:)
-    @donation = donation
-  end
-
+class Confirmation < SimpleDelegator
   def confirm!
-    donation.update!(confirmed: true)
+    update!(confirmed: true)
   end
 
   def decline!
-    donation.update!(declined: true)
+    update!(declined: true)
   end
 
-  attr_reader :donation
+  def request!
+    if pending? && unrequested?
+      ConfirmationRequestJob.perform_now(donation: donation)
+    end
+  end
+
+  alias donation __getobj__
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -14,6 +14,7 @@ class Donation < ActiveRecord::Base
     uniqueness: { scope: :location_id }
 
   delegate(:address, to: :location)
+  delegate(:time_range, to: :scheduled_pickup)
 
   def self.current
     joins(:scheduled_pickup).merge(ScheduledPickup.current)

--- a/app/models/scheduled_pickup.rb
+++ b/app/models/scheduled_pickup.rb
@@ -11,6 +11,10 @@ class ScheduledPickup < ActiveRecord::Base
     where("start_at >= ?", Time.current.beginning_of_day)
   end
 
+  def time_range
+    TimeRange.new(start_at: start_at, end_at: end_at)
+  end
+
   def users
     []
   end

--- a/app/views/donation_mailer/remind.html.erb
+++ b/app/views/donation_mailer/remind.html.erb
@@ -1,8 +1,0 @@
-<h1><%= t(".title", address: @donation.address) %></h1>
-
-<p>
-  <%= t(
-    ".scheduled_pickup",
-    range: format_pickup_time(@donation.scheduled_pickup),
-  ) %>
-</p>

--- a/app/views/donation_mailer/remind.txt.erb
+++ b/app/views/donation_mailer/remind.txt.erb
@@ -1,6 +1,0 @@
-<%= t(".title", address: @donation.address) %>
-
-<%= t(
-  ".scheduled_pickup",
-  range: format_pickup_time(@donation.scheduled_pickup),
-) %>

--- a/app/views/scheduled_pickups/_scheduled_pickup.html.erb
+++ b/app/views/scheduled_pickups/_scheduled_pickup.html.erb
@@ -3,6 +3,6 @@
     <%= t(".header") %>
   </dt>
   <dd>
-    <%= format_pickup_time(scheduled_pickup) %>
+    <%= scheduled_pickup.time_range %>
   </dd>
 </dl>

--- a/app/views/scheduled_pickups/show.html.erb
+++ b/app/views/scheduled_pickups/show.html.erb
@@ -5,7 +5,7 @@
   </header>
   <section class="zipcode-content-section">
     <h2 class="section-label">Scheduled Pickup Time</h2>
-    <span><%= format_pickup_time(@scheduled_pickup) %></span>
+    <span><%= @scheduled_pickup.time_range %></span>
 
     <%= link_to(
       [:edit, @scheduled_pickup.zone, @scheduled_pickup],

--- a/spec/models/confirmation_spec.rb
+++ b/spec/models/confirmation_spec.rb
@@ -4,7 +4,7 @@ describe Confirmation do
   describe "#confirm!" do
     it "confirms the donation" do
       donation = build(:donation, confirmed: nil)
-      confirmation = Confirmation.new(donation: donation)
+      confirmation = Confirmation.new(donation)
 
       confirmation.confirm!
 
@@ -15,7 +15,7 @@ describe Confirmation do
   describe "#decline!" do
     it "declines the donation" do
       donation = build(:donation, declined: false)
-      confirmation = Confirmation.new(donation: donation)
+      confirmation = Confirmation.new(donation)
 
       confirmation.decline!
 

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -11,6 +11,7 @@ describe Donation do
   it { should validate_presence_of(:location) }
 
   it { should delegate_method(:address).to(:location) }
+  it { should delegate_method(:time_range).to(:scheduled_pickup) }
 
   context "uniqueness" do
     subject { create(:donation) }

--- a/spec/models/scheduled_pickup_spec.rb
+++ b/spec/models/scheduled_pickup_spec.rb
@@ -36,4 +36,26 @@ describe ScheduledPickup do
       today - 1.day
     end
   end
+
+  describe "#time_range" do
+    it "constructs a TimeRange from the start and end times" do
+      scheduled_pickup = build_stubbed(:scheduled_pickup)
+      stubbed_time_range = stub_time_range_for(scheduled_pickup)
+
+      time_range = scheduled_pickup.time_range
+
+      expect(time_range).to be stubbed_time_range
+    end
+
+    def stub_time_range_for(pickup)
+      time_range = double
+
+      allow(TimeRange).
+        to receive(:new).
+        with(start_at: pickup.start_at, end_at: pickup.end_at).
+        and_return(time_range)
+
+      time_range
+    end
+  end
 end


### PR DESCRIPTION
Additionally define `ScheduledPickup#time_range` for formatting pickup
times.

Using this directly in templates makes
`ScheduledPickupsHelper.format_pickup_time` unnecessary.

This commit removes all occurrences of `format_pickup_time`, along with
the defunct `donation_mailer/remind` email templates.