### PR TITLE
Request Donation Confirmation via Email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,8 +53,10 @@ group :development, :staging do
 end
 
 group :test do
+  gem "capybara-email"
   gem "capybara-webkit"
   gem "database_cleaner"
+  gem "email_spec"
   gem "formulaic"
   gem "launchy"
   gem "shoulda-matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-email (2.5.0)
+      capybara (~> 2.4)
+      mail
     capybara-webkit (1.8.0)
       capybara (>= 2.3.0, < 2.7.0)
       json
@@ -88,6 +91,9 @@ GEM
     dotenv-rails (2.1.0)
       dotenv (= 2.1.0)
       railties (>= 4.0, < 5.1)
+    email_spec (1.6.0)
+      launchy (~> 2.1)
+      mail (~> 2.2)
     email_validator (1.6.0)
       activemodel
     erubis (2.7.0)
@@ -274,11 +280,13 @@ DEPENDENCIES
   bourbon (= 5.0.0.beta.5)
   bullet
   bundler-audit (>= 0.5.0)
+  capybara-email
   capybara-webkit
   clearance (~> 1.13.0)
   database_cleaner
   delayed_job_active_record
   dotenv-rails
+  email_spec
   email_validator
   factory_girl_rails
   flutie

--- a/app/jobs/confirmation_request_job.rb
+++ b/app/jobs/confirmation_request_job.rb
@@ -1,0 +1,8 @@
+class ConfirmationRequestJob < ActiveJob::Base
+  def perform(donation:)
+    if donation.unrequested?
+      DonationsMailer.request_confirmation(donation: donation).deliver_now
+      donation.update!(requested: true)
+    end
+  end
+end

--- a/app/mailers/donations_mailer.rb
+++ b/app/mailers/donations_mailer.rb
@@ -1,0 +1,11 @@
+class DonationsMailer < ActionMailer::Base
+  def request_confirmation(donation:)
+    @confirmation = Confirmation.new(donation)
+
+    mail(
+      to: donation.donor.email,
+      subject: t(".subject", range: @confirmation.time_range),
+      from: "support@freshfoodconnect.com",
+    )
+  end
+end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -1,6 +1,7 @@
 class Donation < ActiveRecord::Base
   time_for_a_boolean :confirmed
   time_for_a_boolean :declined
+  time_for_a_boolean :requested
 
   belongs_to :scheduled_pickup, touch: true
   belongs_to :location, touch: true
@@ -18,6 +19,22 @@ class Donation < ActiveRecord::Base
 
   def self.current
     joins(:scheduled_pickup).merge(ScheduledPickup.current)
+  end
+
+  def self.pending
+    where(confirmed_at: nil, declined_at: nil)
+  end
+
+  def self.scheduled_for_pick_up_within(hours:)
+    joins(:scheduled_pickup).
+      where(
+        "scheduled_pickups.start_at BETWEEN NOW() AND :cutoff",
+        cutoff: hours.hours.from_now,
+      )
+  end
+
+  def unrequested?
+    !requested?
   end
 
   def declined?

--- a/app/views/donations_mailer/request_confirmation.html.erb
+++ b/app/views/donations_mailer/request_confirmation.html.erb
@@ -1,0 +1,7 @@
+<p><%= t(".time_range", range: @confirmation.time_range) %></p>
+
+<p><%= t(".prompt") %></p>
+
+<%= link_to edit_donation_url(@confirmation) do %>
+  <%= t(".edit") %>
+<% end %>

--- a/app/views/donations_mailer/request_confirmation.txt.erb
+++ b/app/views/donations_mailer/request_confirmation.txt.erb
@@ -1,0 +1,5 @@
+<%= t(".time_range", range: @confirmation.time_range) %>
+
+<%= t(".prompt") %>
+
+<%= t(".edit") %> (<%= edit_donation_url(@confirmation) %>)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,13 @@ en:
     update:
       success: "Donation updated."
 
+  donations_mailer:
+    request_confirmation:
+      edit: "Confirm my donation"
+      prompt: "Do you have fresh vegetables to donate this week?"
+      subject: "Please confirm your donation for %{range}"
+      time_range: "We'll be in your area %{range}."
+
   marketing:
     index:
       heading: "Get started with Fresh Food Connect"

--- a/db/migrate/20160411213708_add_requested_at_to_donations.rb
+++ b/db/migrate/20160411213708_add_requested_at_to_donations.rb
@@ -1,0 +1,5 @@
+class AddRequestedAtToDonations < ActiveRecord::Migration
+  def change
+    add_column :donations, :requested_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 20160412195540) do
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
     t.integer  "size",                default: 0, null: false
+    t.datetime "requested_at"
     t.text     "notes"
   end
 

--- a/lib/tasks/confirmations.rake
+++ b/lib/tasks/confirmations.rake
@@ -1,0 +1,8 @@
+namespace :confirmations do
+  desc "Send donation confirmation requests"
+  task request: :environment do
+    Donation.scheduled_for_pick_up_within(hours: 48).pending.each do |donation|
+      Confirmation.new(donation).request!
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,7 +4,9 @@ FactoryGirl.define do
 
   factory :donation do
     location
+    pending
     scheduled_pickup
+    unrequested
 
     trait :confirmed do
       confirmed true
@@ -17,6 +19,14 @@ FactoryGirl.define do
     trait :pending do
       confirmed false
       declined false
+    end
+
+    trait :requested do
+      requested true
+    end
+
+    trait :unrequested do
+      requested false
     end
   end
 

--- a/spec/features/system_requests_confirmation_from_donor_spec.rb
+++ b/spec/features/system_requests_confirmation_from_donor_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+require "rake"
+
+feature "System requests confirmation from donor" do
+  around do |example|
+    Timecop.freeze { example.run }
+  end
+
+  scenario "48 hours in advance of a scheduled pickup" do
+    scheduled_pickup = schedule_pickup(48.hours.from_now)
+    donation = create(:donation, :pending, scheduled_pickup: scheduled_pickup)
+    donor = donation.donor
+    ensure_donor_is_signed_in(donor)
+
+    schedule_initial_confirmation_requests!
+    open_email(donor.email)
+    edit_donation_through_email_link
+
+    expect(page).to have_donation_edit_header
+    expect(current_email.subject).
+      to have_confirmation_request_subject_for(donation)
+  end
+
+  def have_donation_edit_header
+    have_text t("donations.edit.header")
+  end
+
+  def edit_donation_through_email_link
+    current_email.click_on t("donations_mailer.request_confirmation.edit")
+  end
+
+  def ensure_donor_is_signed_in(donor)
+    visit root_path(as: donor)
+  end
+
+  def have_confirmation_request_subject_for(donation)
+    subject = t(
+      "donations_mailer.request_confirmation.subject",
+      range: donation.time_range,
+    )
+
+    eq(subject)
+  end
+
+  def schedule_initial_confirmation_requests!
+    Rake::Task["confirmations:request"].invoke
+  end
+
+  def schedule_pickup(start_at)
+    create(:scheduled_pickup, start_at: start_at, end_at: start_at - 1.hour)
+  end
+
+  before :all do
+    Rake.application.rake_require "tasks/confirmations"
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/jobs/confirmation_request_job_spec.rb
+++ b/spec/jobs/confirmation_request_job_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe ConfirmationRequestJob do
+  describe ".perform_now" do
+    context "when the Donation has not yet been requested" do
+      it "sends a confirmation request email" do
+        donation = create(:donation, :unrequested)
+        mail = stub_confirmation_mailer(donation: donation)
+
+        ConfirmationRequestJob.perform_now(donation: donation)
+
+        expect(mail).to have_received(:deliver_now)
+        expect(donation).to be_requested
+      end
+    end
+
+    context "when the Donation has already been requested" do
+      it "does nothing" do
+        donation = create(:donation, :requested)
+        mail = stub_confirmation_mailer(donation: donation)
+
+        ConfirmationRequestJob.perform_now(donation: donation)
+
+        expect(mail).not_to have_received(:deliver_now)
+      end
+    end
+  end
+
+  def stub_confirmation_mailer(donation:)
+    mail = double(deliver_now: true)
+
+    allow(DonationsMailer).
+      to receive(:request_confirmation).
+      with(donation: donation).
+      and_return(mail)
+
+    mail
+  end
+end

--- a/spec/mailers/donations_mailer_spec.rb
+++ b/spec/mailers/donations_mailer_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe DonationsMailer do
+  include EmailSpec::Helpers
+  include EmailSpec::Matchers
+  include Rails.application.routes.url_helpers
+
+  describe "#request_confirmation" do
+    it "includes a link to the Donation's edit page" do
+      donation = create(:donation, :pending)
+      donor = donation.donor
+
+      mail = DonationsMailer.request_confirmation(donation: donation)
+
+      expect(mail).to be_delivered_to(donor.email)
+      expect(mail).to have_subject_for(donation)
+      expect(mail).to mention_time_range_for(donation)
+
+      expect(mail).to have_confirmation_prompt
+      expect(mail).to have_edit_link_for(donation)
+    end
+  end
+
+  def have_edit_link_for(donation)
+    have_body_text(edit_donation_url(donation))
+  end
+
+  def have_confirmation_prompt
+    have_body_text(t("donations_mailer.request_confirmation.prompt"))
+  end
+
+  def mention_time_range_for(donation)
+    have_body_text donation.time_range.to_s
+  end
+
+  def have_subject_for(donation)
+    have_subject subject_for(donation)
+  end
+
+  def subject_for(donation)
+    t(
+      "donations_mailer.request_confirmation.subject",
+      range: donation.time_range,
+    )
+  end
+end

--- a/spec/mailers/previews/donations_preview.rb
+++ b/spec/mailers/previews/donations_preview.rb
@@ -1,0 +1,5 @@
+class DonationsPreview < ActionMailer::Preview
+  def request_confirmation
+    DonationsMailer.request_confirmation(donation: Donation.last)
+  end
+end

--- a/spec/models/confirmation_spec.rb
+++ b/spec/models/confirmation_spec.rb
@@ -22,4 +22,61 @@ describe Confirmation do
       expect(donation).to be_declined
     end
   end
+
+  describe "#request!" do
+    context "when the Donation is pending" do
+      context "and not yet requested" do
+        it "sends a request email" do
+          donation = create(:donation, :pending, :unrequested)
+          confirmation = Confirmation.new(donation)
+          allow(ConfirmationRequestJob).to request_confirmation_for(donation)
+
+          confirmation.request!
+
+          expect(ConfirmationRequestJob).
+            to have_requested_confirmation_for(donation)
+        end
+      end
+
+      context "and already requested" do
+        it "does nothing" do
+          donation = create(:donation, :pending, :requested)
+          confirmation = Confirmation.new(donation)
+          allow(ConfirmationRequestJob).to stub_confirmation
+
+          confirmation.request!
+
+          expect(ConfirmationRequestJob).not_to have_confirmed
+        end
+      end
+    end
+
+    context "when the Donation is not pending" do
+      it "does nothing" do
+        donation = create(:donation, :confirmed)
+        confirmation = Confirmation.new(donation)
+        allow(ConfirmationRequestJob).to stub_confirmation
+
+        confirmation.request!
+
+        expect(ConfirmationRequestJob).not_to have_confirmed
+      end
+    end
+  end
+
+  def have_requested_confirmation_for(donation)
+    have_confirmed.with(donation: donation)
+  end
+
+  def have_confirmed
+    have_received(:perform_now)
+  end
+
+  def stub_confirmation
+    receive(:perform_now)
+  end
+
+  def request_confirmation_for(donation)
+    stub_confirmation.with(donation: donation)
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,8 @@ require File.expand_path("../../config/environment", __FILE__)
 abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]
 
 require "rspec/rails"
+require "capybara/email/rspec"
+require "email_spec"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
 


### PR DESCRIPTION
Additionally define `ScheduledPickup#time_range` for formatting pickup
times.

Using this directly in templates makes
`ScheduledPickupsHelper.format_pickup_time` unnecessary.

This commit removes all occurrences of `format_pickup_time`, along with
the defunct `donation_mailer/remind` email templates.

fixup