### PR TITLE
Show/Edit Location notes on `/profile`

### DIFF
--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -14,6 +14,7 @@
       <h3 class="profile-edit-section__heading"><%= t(".location") %></h3>
       <%= f.input :address %>
       <%= f.input :zipcode %>
+      <%= f.input :notes, as: :text, input_html: { rows: 5 } %>
     </fieldset>
   </div>
 

--- a/app/views/profiles/_profile.html.erb
+++ b/app/views/profiles/_profile.html.erb
@@ -11,7 +11,10 @@
   <%= inline_svg("map.svg", class: "svg-icon") %>
   <%= profile.zipcode %>
 </span>
-<span class="supplier-info__metadata notes">
-  <%= inline_svg("info.svg", class: "svg-icon") %>
-  These are some notes. They shouldn't be too long, so maybe we can set a character limit of 100 characters or so.
-</span>
+
+<% if profile.notes.present? %>
+  <span class="supplier-info__metadata notes">
+    <%= inline_svg("info.svg", class: "svg-icon") %>
+    <%= profile.notes %>
+  </span>
+<% end %>

--- a/spec/features/donor_edits_location_spec.rb
+++ b/spec/features/donor_edits_location_spec.rb
@@ -8,6 +8,7 @@ feature "Donor edits location" do
     new_pickup_location = {
       address: "123 Fake Street Denver CO",
       zipcode: zone.zipcode,
+      notes: "on my porch",
     }
 
     visit root_path(as: donor)
@@ -15,6 +16,7 @@ feature "Donor edits location" do
     edit_pickup_location(new_pickup_location)
 
     expect(page).to have_text(new_pickup_location[:address])
+    expect(page).to have_text(new_pickup_location[:notes])
     expect(page).to have_text(new_pickup_location[:zipcode])
   end
 
@@ -33,15 +35,10 @@ feature "Donor edits location" do
     click_on t("application.header.profile")
   end
 
-  def edit_pickup_location(address:, zipcode:)
+  def edit_pickup_location(**attributes)
     click_on t("profiles.show.edit")
 
-    fill_form_and_submit(
-      :profile,
-      :edit,
-      address: address,
-      zipcode: zipcode,
-    )
+    fill_form_and_submit(:profile, :edit, attributes)
   end
 
   def have_address_errors

--- a/spec/views/profiles/show.html.erb_spec.rb
+++ b/spec/views/profiles/show.html.erb_spec.rb
@@ -9,8 +9,9 @@ describe "profiles/show" do
     )
     location = build_stubbed(
       :location,
-      user: user,
       address: "123 Fake St.",
+      notes: "on the porch",
+      user: user,
       zipcode: "90210",
     )
     build_stubbed(:donation, location: location)
@@ -22,6 +23,7 @@ describe "profiles/show" do
     expect(rendered).to have_text(profile.address)
     expect(rendered).to have_text(profile.email)
     expect(rendered).to have_text(profile.name)
+    expect(rendered).to have_text(profile.notes)
     expect(rendered).to have_text(profile.zipcode)
   end
 


### PR DESCRIPTION
https://trello.com/c/Oz6iPKen

This commit implements the new design for a Profile's notes.