### PR TITLE
Additional Fields for Registration

### DIFF
--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,0 +1,19 @@
+class LocationsController < ApplicationController
+  def update
+    @location = find_location
+
+    @location.update!(location_params)
+
+    redirect_to profile_url, flash: { success: t(".success") }
+  end
+
+  private
+
+  def location_params
+    params.require(:location).permit(:location_type, :grown_on_site)
+  end
+
+  def find_location
+    current_user.location
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -36,8 +36,12 @@ class RegistrationsController < ApplicationController
       permit(
         :address,
         :email,
+        :grown_on_site,
+        :location_type,
         :name,
+        :organic_growth_asserted,
         :password,
+        :terms_and_conditions_accepted,
         :zipcode,
       )
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -4,10 +4,18 @@ class Location < ActiveRecord::Base
 
   has_many :donations, dependent: :destroy
 
+  enum location_type: {
+    residence: 0,
+    community_garden: 1,
+    business: 2,
+    other: 3,
+  }
+
   validates :address, presence: true
-  validates :zone, presence: true
+  validates :location_type, presence: true
   validates :user, presence: true
   validates :zipcode, presence: true, zipcode: { country_code: :us }
+  validates :zone, presence: true
 
   def zipcode=(zipcode)
     super(zipcode.to_s.strip)

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -2,6 +2,10 @@ class Registration
   include ActiveModel::Model
 
   validates :name, presence: true
+  validates :organic_growth_asserted,
+    presence: { message: I18n.t("validations.accepted") }
+  validates :terms_and_conditions_accepted,
+    presence: { message: I18n.t("validations.accepted") }
   validate :zipcode_is_supported
 
   attr_accessor(
@@ -17,14 +21,22 @@ class Registration
     :email=,
     :name,
     :name=,
+    :organic_growth_asserted,
+    :organic_growth_asserted=,
     :password,
     :password=,
+    :terms_and_conditions_accepted,
+    :terms_and_conditions_accepted=,
     to: :user,
   )
 
   delegate(
     :address,
     :address=,
+    :grown_on_site,
+    :grown_on_site=,
+    :location_type,
+    :location_type=,
     :zipcode,
     :zipcode=,
     to: :location,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,20 @@
 class User < ActiveRecord::Base
   include Clearance::User
 
+  time_for_a_boolean :organic_growth_asserted
+  time_for_a_boolean :terms_and_conditions_accepted
+
   has_many :donations, through: :location
   has_one :location, dependent: :destroy
 
   validates :email, presence: true, email: true
+  validates :organic_growth_asserted_at, presence: {
+    message: I18n.t("validations.accepted"),
+  }
   validates :password, presence: true, on: :create
+  validates :terms_and_conditions_accepted_at, presence: {
+    message: I18n.t("validations.accepted"),
+  }
 
   def current_donation
     donations.current.first

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -1,0 +1,13 @@
+<header class="form-container__header">
+  <h3><%= t(".header") %></h3>
+</header>
+
+<%= simple_form_for(location) do |f| %>
+  <div class="form-container__body">
+    <%= render("locations/form_fields", f: f) %>
+  </div>
+
+  <div class="submit-wrapper">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/locations/_form_fields.html.erb
+++ b/app/views/locations/_form_fields.html.erb
@@ -1,0 +1,17 @@
+<div class="label-input-group">
+  <%= f.input(
+    :location_type,
+    as: :radio_buttons,
+    collection: Location.location_types.keys.map(&:to_sym),
+    required: false,
+  ) %>
+</div>
+
+<div class="label-input-group">
+  <%= f.input(
+    :grown_on_site,
+    as: :radio_buttons,
+    collection: [:true, :false],
+    required: false,
+  ) %>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -19,24 +19,8 @@
       </div>
     </div>
 
-    <form action="" class="form-container no-footer">
-      <header class="form-container__header">
-        <h3>Additional Info</h3>
-      </header>
-      <div class="form-container__body">
-        <div class="label-input-group">
-          <label for="pickup-location">Pickup Location Type</label>
-          <input type="radio" name="pickup-location" value="residence" checked> Residence<br>
-          <input type="radio" name="pickup-location" value="community-garden"> Community Garden<br>
-          <input type="radio" name="pickup-location" value="business"> Business<br>
-          <input type="radio" name="pickup-location" value="other"> Other<br>
-        </div>
-        <div class="label-input-group">
-          <label for="source">Where are you growing the food you are donating?</label>
-          <input type="radio" name="source" value="residence" checked> At the pickup location<br>
-          <input type="radio" name="source" value="other"> Somewhere other than the pickup location.<br>
-        </div>
-      </div>
-    </form>
+    <div class="form-container no-footer">
+      <%= render("locations/form", location: @profile.location) %>
+    </div>
   </div>
 </div>

--- a/app/views/registrations/_form.html.erb
+++ b/app/views/registrations/_form.html.erb
@@ -6,21 +6,27 @@
     <%= f.input :zipcode, required: "true" %>
     <%= f.input :email, required: "true" %>
     <%= f.input :password, required: "true" %>
+
     <div class="label-input-group">
-      <label for="pickup-location">Pickup Location Type</label>
-      <input type="radio" name="pickup-location" value="residence" checked> Residence<br>
-      <input type="radio" name="pickup-location" value="community-garden"> Community Garden<br>
-      <input type="radio" name="pickup-location" value="business"> Business<br>
-      <input type="radio" name="pickup-location" value="other"> Other<br>
+      <%= f.input(
+        :location_type,
+        as: :radio_buttons,
+        collection: Location.location_types.keys.map(&:to_sym),
+      ) %>
     </div>
+
     <div class="label-input-group">
-      <label for="source">Where are you growing the food you are donating?</label>
-      <input type="radio" name="source" value="residence" checked> At the pickup location<br>
-      <input type="radio" name="source" value="other"> Somewhere other than the pickup location.<br>
+      <%= f.input(
+        :grown_on_site,
+        as: :radio_buttons,
+        collection: [:true, :false],
+      ) %>
     </div>
-    <input type="checkbox" required> I agree to the <a href="">Terms and Conditions</a><br>
-    <input type="checkbox" required> The food I donate will be grown without the use of non-organic pesticides, herbicides and fertilizers.<br>
+
+    <%= f.input :terms_and_conditions_accepted, as: :boolean %>
+    <%= f.input :organic_growth_asserted, as: :boolean %>
   </div>
+
   <footer class="form-container__footer">
     <%= f.submit %>
   </footer>

--- a/app/views/registrations/_form.html.erb
+++ b/app/views/registrations/_form.html.erb
@@ -7,21 +7,7 @@
     <%= f.input :email, required: "true" %>
     <%= f.input :password, required: "true" %>
 
-    <div class="label-input-group">
-      <%= f.input(
-        :location_type,
-        as: :radio_buttons,
-        collection: Location.location_types.keys.map(&:to_sym),
-      ) %>
-    </div>
-
-    <div class="label-input-group">
-      <%= f.input(
-        :grown_on_site,
-        as: :radio_buttons,
-        collection: [:true, :false],
-      ) %>
-    </div>
+    <%= render("locations/form_fields", f: f) %>
 
     <%= f.input :terms_and_conditions_accepted, as: :boolean %>
     <%= f.input :organic_growth_asserted, as: :boolean %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,6 +88,12 @@ en:
       subject: "Please confirm your donation for %{range}"
       time_range: "We'll be in your area %{range}."
 
+  locations:
+    form:
+      header: "Additional Info"
+    update:
+      success: "Pickup information updated."
+
   marketing:
     index:
       heading: "Get started with Fresh Food Connect"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,7 +129,6 @@ en:
       prompt: "In order to participate in our program, you'll need to create an account so we know where to come make the pickup and to let us know each week if you have veggies available to donate. Please provide us with some information below:"
     new:
       header: "Our service is available in your area!"
-
   subscriptions:
     form:
       prompt: "But there's good news! If you'd like to provide us with your email, we will notify you once we begin service in your area:"
@@ -157,6 +156,7 @@ en:
       text: "There are no pickups scheduled for this week."
 
   validations:
+    accepted: "must be checked"
     unsupported: "We're sorry, our service is not available in %{zipcode} at this time."
 
   zones:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -4,7 +4,7 @@ en:
       donation:
         update: "Update"
       location:
-        update: "Save Pickup Address"
+        update: "Save Pickup Information"
       pre_registration:
         create: "Donate"
       profile:
@@ -37,6 +37,11 @@ en:
       donation:
         size: "How big is your donation?"
         notes: "Provide a short description of your donation:"
+      location:
+        grown_on_site: "Where are you growing the food you are donating?"
+        location_type: "Pickup Location Type"
+        organic_growth_asserted: "The food I donate will be grown without the use of non-organic pesticides, herbicides and fertilizers."
+        terms_and_conditions_accepted: I agree to the Terms and Conditions
       profile:
         address: "Street Address for Pickup"
         notes: "Pickup Notes"
@@ -58,6 +63,16 @@ en:
           large: "Large"
           medium: "Medium"
           small: "Small"
+      location:
+        grown_on_site:
+          "false": "Somewhere other than the pickup location."
+          "true": "At the pickup location"
+        location_type:
+          business: "Business"
+          community_garden: "Community Garden"
+          other: "Other"
+          residence: "Residence"
+
       registration:
         grown_on_site:
           "false": "Somewhere other than the pickup location."

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -40,6 +40,11 @@ en:
       profile:
         address: "Street Address for Pickup"
         notes: "Pickup Notes"
+      registration:
+        terms_and_conditions_accepted: I agree to the Terms and Conditions
+        organic_growth_asserted: "The food I donate will be grown without the use of non-organic pesticides, herbicides and fertilizers."
+        location_type: "Pickup Location Type"
+        grown_on_site: "Where are you growing the food you are donating?"
       scheduled_pickup:
         end_at: "Latest pickup"
         start_at: "Earliest pickup"
@@ -53,6 +58,15 @@ en:
           large: "Large"
           medium: "Medium"
           small: "Small"
+      registration:
+        grown_on_site:
+          "false": "Somewhere other than the pickup location."
+          "true": "At the pickup location"
+        location_type:
+          business: "Business"
+          community_garden: "Community Garden"
+          other: "Other"
+          residence: "Residence"
 
     # Examples
     # labels:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :donations, only: [:edit, :update] do
     resource :confirmation, only: [:create, :destroy, :update]
   end
+  resource :location, only: [:update]
   resources :pre_registrations, only: [:create]
   resources :registrations, only: [:create, :new]
   resources :subscriptions, only: [:create, :new]

--- a/db/migrate/20160413203227_add_metadata_to_locations.rb
+++ b/db/migrate/20160413203227_add_metadata_to_locations.rb
@@ -1,0 +1,6 @@
+class AddMetadataToLocations < ActiveRecord::Migration
+  def change
+    add_column :locations, :location_type, :integer, null: false, default: 0
+    add_column :locations, :grown_on_site, :boolean, null: false, default: true
+  end
+end

--- a/db/migrate/20160413211359_add_terms_and_conditions_accepted_at_to_users.rb
+++ b/db/migrate/20160413211359_add_terms_and_conditions_accepted_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddTermsAndConditionsAcceptedAtToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :terms_and_conditions_accepted_at, :timestamp
+  end
+end

--- a/db/migrate/20160413212858_add_organic_growth_asserted_at_to_users.rb
+++ b/db/migrate/20160413212858_add_organic_growth_asserted_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddOrganicGrowthAssertedAtToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :organic_growth_asserted_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,8 +40,8 @@ ActiveRecord::Schema.define(version: 20160413212858) do
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
     t.integer  "size",                default: 0, null: false
-    t.datetime "requested_at"
     t.text     "notes"
+    t.datetime "requested_at"
   end
 
   add_index "donations", ["location_id", "scheduled_pickup_id"], name: "index_donations_on_location_id_and_scheduled_pickup_id", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160412195540) do
+ActiveRecord::Schema.define(version: 20160413212858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,10 +48,12 @@ ActiveRecord::Schema.define(version: 20160412195540) do
   add_index "donations", ["size"], name: "index_donations_on_size", using: :btree
 
   create_table "locations", force: :cascade do |t|
-    t.string  "address",              null: false
-    t.string  "zipcode",              null: false
-    t.text    "notes",   default: "", null: false
-    t.integer "user_id",              null: false
+    t.string  "address",                      null: false
+    t.string  "zipcode",                      null: false
+    t.text    "notes",         default: "",   null: false
+    t.integer "user_id",                      null: false
+    t.integer "location_type", default: 0,    null: false
+    t.boolean "grown_on_site", default: true, null: false
   end
 
   create_table "scheduled_pickups", force: :cascade do |t|
@@ -73,14 +75,16 @@ ActiveRecord::Schema.define(version: 20160412195540) do
   add_index "subscriptions", ["zipcode"], name: "index_subscriptions_on_zipcode", using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.datetime "created_at",                                     null: false
-    t.datetime "updated_at",                                     null: false
-    t.string   "email",                                          null: false
-    t.string   "encrypted_password", limit: 128,                 null: false
-    t.string   "confirmation_token", limit: 128
-    t.string   "remember_token",     limit: 128,                 null: false
-    t.string   "name",                           default: "",    null: false
-    t.boolean  "admin",                          default: false, null: false
+    t.datetime "created_at",                                                   null: false
+    t.datetime "updated_at",                                                   null: false
+    t.string   "email",                                                        null: false
+    t.string   "encrypted_password",               limit: 128,                 null: false
+    t.string   "confirmation_token",               limit: 128
+    t.string   "remember_token",                   limit: 128,                 null: false
+    t.string   "name",                                         default: "",    null: false
+    t.boolean  "admin",                                        default: false, null: false
+    t.datetime "terms_and_conditions_accepted_at"
+    t.datetime "organic_growth_asserted_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -37,6 +37,10 @@ FactoryGirl.define do
 
     supported
 
+    trait :residence do
+      location_type :residence
+    end
+
     trait :supported do
       zone
     end
@@ -49,6 +53,8 @@ FactoryGirl.define do
     address "123 Fake Street"
     name "New User"
     password "password"
+    organic_growth_asserted true
+    terms_and_conditions_accepted true
 
     email
   end
@@ -72,6 +78,8 @@ FactoryGirl.define do
   factory :user do
     email
     password "password"
+    organic_growth_asserted true
+    terms_and_conditions_accepted true
 
     factory :donor do
       with_location

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -33,9 +33,15 @@ FactoryGirl.define do
   factory :location do
     address "123 Fake Street"
 
+    residence
+    grown_on_site
     user
 
     supported
+
+    trait :grown_on_site do
+      grown_on_site true
+    end
 
     trait :residence do
       location_type :residence

--- a/spec/features/donor_edits_pickup_location_spec.rb
+++ b/spec/features/donor_edits_pickup_location_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+feature "Donor edits pickup location" do
+  scenario "from profile" do
+    location = create(:location, :residence, :grown_on_site)
+    donor = create(:donor, location: location)
+    new_settings = {
+      location_type: "business",
+      grown_on_site: false,
+    }
+
+    visit root_path(as: donor)
+    edit_location(new_settings)
+
+    expect(page).to have_success_flash
+    expect(page).to have_setting(new_settings[:location_type])
+    expect(page).to have_setting(new_settings[:grown_on_site])
+  end
+
+  def have_success_flash
+    have_text t("locations.update.success")
+  end
+
+  def have_setting(value)
+    have_css(%{[checked][value="#{value}"]})
+  end
+
+  def edit_location(location_type:, grown_on_site:, **attributes)
+    choose option_for(:location_type, location_type)
+    choose option_for(:grown_on_site, grown_on_site)
+
+    fill_form_and_submit(:location, :edit, attributes)
+  end
+
+  def option_for(key, value)
+    t("simple_form.options.location.#{key}.#{value}")
+  end
+end

--- a/spec/features/donor_signs_up_spec.rb
+++ b/spec/features/donor_signs_up_spec.rb
@@ -9,17 +9,79 @@ feature "Donor signs up" do
 
       visit root_path
       pre_register_with_zipcode(zone.zipcode)
-      register_donor(address: supported_location.address, email: user.email)
+      register_donor(
+        address: supported_location.address,
+        email: user.email,
+        location_type: last_location_type,
+        grown_on_site: !supported_location.grown_on_site,
+      )
 
       expect(page).to have_text(user.email)
+      expect(page).not_to have_validation_error
     end
   end
 
-  def register_donor(address:, email:)
+  context "without accepting the Terms and Conditions" do
+    scenario "displays validation errors" do
+      zone = create(:zone)
+      supported_location = build_stubbed(:location, zone: zone)
+      user = build_stubbed(:user)
+
+      visit root_path
+      pre_register_with_zipcode(zone.zipcode)
+      register_donor(
+        address: supported_location.address,
+        email: user.email,
+        terms_and_conditions_accepted: false,
+      )
+
+      expect(page).to have_validation_error
+    end
+  end
+
+  context "without asserting their donations are organic" do
+    scenario "displays validation errors" do
+      zone = create(:zone)
+      supported_location = build_stubbed(:location, zone: zone)
+      user = build_stubbed(:user)
+
+      visit root_path
+      pre_register_with_zipcode(zone.zipcode)
+      register_donor(
+        address: supported_location.address,
+        email: user.email,
+        organic_growth_asserted: false,
+      )
+
+      expect(page).to have_validation_error
+    end
+  end
+
+  def have_validation_error
+    have_text t("validations.accepted")
+  end
+
+  def last_location_type
+    Location.location_types.keys.last.to_sym
+  end
+
+  def register_donor(location_type: nil, grown_on_site: nil, **options)
     attributes = attributes_for(:registration).
-      merge(address: address, email: email)
+      merge(options)
+
+    unless grown_on_site.nil?
+      choose option_for(:grown_on_site, grown_on_site)
+    end
+
+    if location_type.present?
+      choose option_for(:location_type, location_type)
+    end
 
     fill_form_and_submit(:registration, :new, attributes)
+  end
+
+  def option_for(key, value)
+    t("simple_form.options.registration.#{key}.#{value}")
   end
 
   def pre_register_with_zipcode(zipcode)

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -5,10 +5,20 @@ describe Location do
   it { should belong_to(:user).touch(true) }
   it { should belong_to(:zone) }
 
+  it do
+    should define_enum_for(:location_type).with(
+      residence: 0,
+      community_garden: 1,
+      business: 2,
+      other: 3,
+    )
+  end
+
   it { should validate_presence_of(:address) }
-  it { should validate_presence_of(:zone) }
+  it { should validate_presence_of(:location_type) }
   it { should validate_presence_of(:user) }
   it { should validate_presence_of(:zipcode) }
+  it { should validate_presence_of(:zone) }
 
   describe "#zipcode=" do
     it "trims whitespace" do

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -6,6 +6,15 @@ describe Registration do
   it { should validate_presence_of(:name) }
   it { should validate_presence_of(:zipcode) }
 
+  it do
+    should validate_presence_of(:organic_growth_asserted).
+      with_message(t("validations.accepted"))
+  end
+  it do
+    should validate_presence_of(:terms_and_conditions_accepted).
+      with_message(t("validations.accepted"))
+  end
+
   describe "validations" do
     context "when a Location has an unsupported zipcode" do
       it "exposes errors for :zipcode" do
@@ -37,7 +46,7 @@ describe Registration do
     describe "#save" do
       context "when valid" do
         it "creates a User with a Location" do
-          location = build(:location, :supported)
+          location = build(:location, :supported, :residence)
           registration = build(:registration, zipcode: location.zipcode)
 
           saved = registration.save
@@ -46,22 +55,25 @@ describe Registration do
 
           expect(saved).to be true
           expect(registration).to have_attributes(
-            valid?: true,
             invalid?: false,
+            valid?: true,
           )
           expect(user).to have_attributes(
-            name: registration.name,
             email: registration.email,
             location: location,
+            name: registration.name,
             persisted?: true,
+            terms_and_conditions_accepted: true,
             valid?: true,
           )
           expect(location).to have_attributes(
             address: registration.address,
-            user: user,
-            zipcode: registration.zipcode,
+            grown_on_site?: true,
+            location_type: "residence",
             persisted?: true,
+            user: user,
             valid?: true,
+            zipcode: registration.zipcode,
           )
         end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,15 @@ describe User do
   it { should validate_presence_of(:email) }
   it { should validate_presence_of(:password).on(:create) }
 
+  it do
+    should validate_presence_of(:organic_growth_asserted_at).
+      with_message(t("validations.accepted"))
+  end
+  it do
+    should validate_presence_of(:terms_and_conditions_accepted_at).
+      with_message(t("validations.accepted"))
+  end
+
   describe "#current_donation" do
     context "when the donor is registered with a Zone scheduled for pickups" do
       it "returns their donation" do

--- a/spec/views/profiles/show.html.erb_spec.rb
+++ b/spec/views/profiles/show.html.erb_spec.rb
@@ -10,6 +10,8 @@ describe "profiles/show" do
     location = build_stubbed(
       :location,
       address: "123 Fake St.",
+      grown_on_site: false,
+      location_type: "business",
       notes: "on the porch",
       user: user,
       zipcode: "90210",
@@ -25,6 +27,8 @@ describe "profiles/show" do
     expect(rendered).to have_text(profile.name)
     expect(rendered).to have_text(profile.notes)
     expect(rendered).to have_text(profile.zipcode)
+    expect(rendered).to have_selected(location.location_type)
+    expect(rendered).to have_selected(location.grown_on_site)
   end
 
   context "when there isn't a current donation" do
@@ -37,6 +41,10 @@ describe "profiles/show" do
 
       expect(rendered).to have_unscheduled_donation_text
     end
+  end
+
+  def have_selected(value)
+    have_css %{[checked][value="#{value}"]}
   end
 
   def have_unscheduled_donation_text


### PR DESCRIPTION
**Add additional fields to registration form**

https://trello.com/c/DcpszTGS

This commit adds additional required fields to the registration form,
including:

* The type of pickup location
* Whether or not the food is grown on site at the pickup location
* Whether or not the registrant accepts the terms and conditions
* Whether or not the registrant is growing food without non-organic
  pesticides

**Allow editing Pickup Location fields from Profile**

https://trello.com/c/DcpszTGS

This commit enables donors to change settings about their pickup
location, like:

* What type of location it is
* Whether or not their donation is grown on site at said location