### PR TITLE
Display confirmation email time

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,22 @@ you can deploy to staging and production with:
 
     $ ./bin/deploy staging
     $ ./bin/deploy production
+
+## Scheduling Pickups
+
+Our [staging][] and [production][] applications are deployed to Heroku.
+
+We use the [Heroku Scheduler][scheduler] addon to run our scheduling-focussed
+Rake tasks on a nightly basis.
+
+Each night, the scheduler will run the following tasks:
+
+* `pickups:schedule` - creates `ScheduledPickup` rows for any active
+  zipcodes without pickups scheduled for the week. This task is idempotent.
+* `confirmations:request` - sends Confirmation Request emails to donors
+  associated with `ScheduledPickup`s scheduled to occur within the next `48`
+  hours.
+
+[staging]: https://dashboard.heroku.com/apps/freshfoodconnect-staging
+[production]: https://dashboard.heroku.com/apps/freshfoodconnect-production
+[scheduler]: https://elements.heroku.com/addons/scheduler

--- a/app/models/scheduled_pickup.rb
+++ b/app/models/scheduled_pickup.rb
@@ -1,4 +1,6 @@
 class ScheduledPickup < ActiveRecord::Base
+  HOURS_IN_ADVANCE_FOR_CONFIRMATION = 48
+
   belongs_to :zone
 
   validates :zone, presence: true
@@ -13,6 +15,10 @@ class ScheduledPickup < ActiveRecord::Base
 
   def time_range
     TimeRange.new(start_at: start_at, end_at: end_at)
+  end
+
+  def confirmation_requested_at
+    start_at - HOURS_IN_ADVANCE_FOR_CONFIRMATION.hours
   end
 
   def users

--- a/app/views/scheduled_pickups/show.html.erb
+++ b/app/views/scheduled_pickups/show.html.erb
@@ -3,8 +3,9 @@
     <h2><%= @scheduled_pickup.zipcode %></h2>
     <span class="zipcode-activation-status">Active</span>
   </header>
+
   <section class="zipcode-content-section">
-    <h2 class="section-label">Scheduled Pickup Time</h2>
+    <h2 class="section-label"><%= t(".time") %></h2>
     <span><%= @scheduled_pickup.time_range %></span>
 
     <%= link_to(
@@ -14,8 +15,19 @@
       <%= t(".edit") %>
     <% end %>
   </section>
+
   <section class="zipcode-content-section">
-    <h2 class="section-label">Suppliers</h2>
+    <h2 class="section-label"><%= t(".confirmation.header") %></h2>
+    <span>
+      <%= t(
+        ".confirmation.time",
+        time: l(@scheduled_pickup.confirmation_requested_at, format: :at),
+      ) %>
+    </span>
+  </section>
+
+  <section class="zipcode-content-section">
+    <h2 class="section-label"><%= t(".suppliers") %></h2>
     <table>
       <thead>
         <tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,7 +126,12 @@ en:
     scheduled_pickup:
       header: "Scheduled Pickup Time"
     show:
+      confirmation:
+        header: "Scheduled Confirmation Time"
+        time: "Confirmations will be requested before %{time}"
       edit: "Edit"
+      suppliers: "Suppliers"
+      time: "Scheduled Pickup Time"
     update:
       success: "The pickup has been rescheduled."
 
@@ -144,6 +149,8 @@ en:
 
   time:
     formats:
+      at:
+        "%A at %l:%M %P"
       default:
         "%a, %b %-d, %Y at %r"
       date:

--- a/lib/tasks/confirmations.rake
+++ b/lib/tasks/confirmations.rake
@@ -1,7 +1,12 @@
 namespace :confirmations do
   desc "Send donation confirmation requests"
   task request: :environment do
-    Donation.scheduled_for_pick_up_within(hours: 48).pending.each do |donation|
+    hours = ScheduledPickup::HOURS_IN_ADVANCE_FOR_CONFIRMATION
+
+    Donation.
+      scheduled_for_pick_up_within(hours: hours).
+      pending.
+      each do |donation|
       Confirmation.new(donation).request!
     end
   end

--- a/spec/features/admin_views_pickup_times_spec.rb
+++ b/spec/features/admin_views_pickup_times_spec.rb
@@ -14,6 +14,11 @@ feature "Admin views pickup time", :rake do
     view_zone(zone)
 
     expect(page).to have_text("Wednesday between 1:00 pm and 3:00 pm")
+    expect(page).to have_confirmation_time("Monday at 1:00 pm")
+  end
+
+  def have_confirmation_time(time)
+    have_text t("scheduled_pickups.show.confirmation.time", time: time)
   end
 
   def wednesday

--- a/spec/models/scheduled_pickup_spec.rb
+++ b/spec/models/scheduled_pickup_spec.rb
@@ -37,6 +37,20 @@ describe ScheduledPickup do
     end
   end
 
+  describe "#confirmation_requested_at" do
+    around do |example|
+      Timecop.freeze { example.run }
+    end
+
+    it "returns a time 48 in advance of the earliest pickup time" do
+      scheduled_pickup = create(:scheduled_pickup, start_at: 48.hours.from_now)
+
+      confirmation_requested_at = scheduled_pickup.confirmation_requested_at
+
+      expect(confirmation_requested_at).to eq(Time.current)
+    end
+  end
+
   describe "#time_range" do
     it "constructs a TimeRange from the start and end times" do
       scheduled_pickup = build_stubbed(:scheduled_pickup)


### PR DESCRIPTION

<img width="692" alt="screen shot 2016-04-14 at 11 56 15 am" src="https://cloud.githubusercontent.com/assets/2575027/14534599/eab3fbf8-0237-11e6-9519-b8a2919f1b18.png">

https://trello.com/c/vWs6DoOg

When an admin views a pickup schedule, display the approximate time that
donors will be emailed to confirm their donations.