### PR TITLE
Schedule pickups for current week

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby "2.3.0"
 
 gem "autoprefixer-rails"
 gem "bourbon", "5.0.0.beta.5"
+gem "chronic"
 gem "clearance", "~> 1.13.0"
 gem "delayed_job_active_record"
 gem "email_validator"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     capybara-webkit (1.8.0)
       capybara (>= 2.3.0, < 2.7.0)
       json
+    chronic (0.10.2)
     clearance (1.13.0)
       bcrypt
       email_validator (~> 1.4)
@@ -282,6 +283,7 @@ DEPENDENCIES
   bundler-audit (>= 0.5.0)
   capybara-email
   capybara-webkit
+  chronic
   clearance (~> 1.13.0)
   database_cleaner
   delayed_job_active_record

--- a/app/models/pickup_scheduler.rb
+++ b/app/models/pickup_scheduler.rb
@@ -42,22 +42,22 @@ class PickupScheduler
   end
 
   def end_time
-    scheduled_date + end_hour.hours
+    pickup_day + end_hour.hours
   end
 
   def start_time
-    scheduled_date + start_hour.hours
+    pickup_day + start_hour.hours
   end
 
-  def scheduled_date
-    start_of_week + offset_into_week
+  def pickup_day
+    Chronic.parse(
+      day_of_week,
+      conext: :next,
+      now: Time.current,
+    ).beginning_of_day
   end
 
-  def offset_into_week
-    weekday.days
-  end
-
-  def start_of_week
-    Time.current.sunday.beginning_of_day
+  def day_of_week
+    Weekday.find(weekday)
   end
 end

--- a/app/models/time_range.rb
+++ b/app/models/time_range.rb
@@ -7,7 +7,7 @@ class TimeRange
   def to_s
     I18n.t(
       "time_ranges.format",
-      weekday: weekday.label,
+      date: I18n.l(date, format: :long_with_weekday),
       start_at: format(start_at),
       end_at: format(end_at),
     )
@@ -25,7 +25,7 @@ class TimeRange
     datetime.strftime(FORMAT).strip
   end
 
-  def weekday
-    Weekday.find(start_at.wday)
+  def date
+    start_at.to_date
   end
 end

--- a/app/models/weekday.rb
+++ b/app/models/weekday.rb
@@ -18,4 +18,8 @@ class Weekday
     @label = label
     @value = value
   end
+
+  def to_s
+    label
+  end
 end

--- a/config/initializers/chronic.rb
+++ b/config/initializers/chronic.rb
@@ -1,0 +1,1 @@
+Chronic.time_class = Time.zone

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,8 @@ en:
         "%m/%d/%Y"
       with_weekday:
         "%a %m/%d/%y"
+      long_with_weekday:
+        "%A %B %-d, %Y"
     hours:
       - "12:00 am"
       - "1:00 am"
@@ -150,7 +152,7 @@ en:
   time:
     formats:
       at:
-        "%A at %l:%M %P"
+        "%A %B %-d, %Y at %l:%M %P"
       default:
         "%a, %b %-d, %Y at %r"
       date:
@@ -159,7 +161,7 @@ en:
         "%B %d"
 
   time_ranges:
-    format: "%{weekday} between %{start_at} and %{end_at}"
+    format: "%{date} between %{start_at} and %{end_at}"
 
   titles:
     application: Fresh Food Connect

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -11,7 +11,7 @@ if Rails.env.development? || Rails.env.test?
         zipcode: "80205",
         start_hour: 13,
         end_hour: 15,
-        weekday: Date::DAYNAMES.index("Thursday"),
+        weekday: Date::DAYNAMES.index("Friday"),
       )
       registration = create(
         :registration,

--- a/spec/features/admin_views_pickup_times_spec.rb
+++ b/spec/features/admin_views_pickup_times_spec.rb
@@ -1,28 +1,34 @@
 require "rails_helper"
 require "rake"
 
-feature "Admin views pickup time", :rake do
+feature "Admin views pickup time" do
   scenario "generated weekly" do
-    zone = create(
-      :zone,
-      start_hour: 13,
-      end_hour: 15,
-      weekday: wednesday,
-    )
-    schedule_pickups!
+    friday = thursday + 1.day
 
-    view_zone(zone)
+    Timecop.freeze(thursday) do
+      zone = create(
+        :zone,
+        start_hour: 13,
+        end_hour: 15,
+        weekday: friday.wday,
+      )
+      schedule_pickups!
 
-    expect(page).to have_text("Wednesday between 1:00 pm and 3:00 pm")
-    expect(page).to have_confirmation_time("Monday at 1:00 pm")
+      view_zone(zone)
+
+      expect(page).
+        to have_text("Friday April 15, 2016 between 1:00 pm and 3:00 pm")
+      expect(page).
+        to have_confirmation_time("Wednesday April 13, 2016 at 1:00 pm")
+    end
   end
 
   def have_confirmation_time(time)
     have_text t("scheduled_pickups.show.confirmation.time", time: time)
   end
 
-  def wednesday
-    Weekday.find(3).value
+  def thursday
+    Date.new(2016, 4, 14).beginning_of_day
   end
 
   def view_zone(zone)

--- a/spec/models/time_range_spec.rb
+++ b/spec/models/time_range_spec.rb
@@ -9,7 +9,8 @@ describe TimeRange do
       time_range = TimeRange.new(start_at: start_at, end_at: end_at)
       formatted = time_range.to_s
 
-      expect(formatted).to eq("Wednesday between 12:00 am and 1:00 am")
+      expect(formatted).
+        to eq("Wednesday April 13, 2016 between 12:00 am and 1:00 am")
     end
   end
 end


### PR DESCRIPTION

<img width="700" alt="screen shot 2016-04-14 at 2 42 22 pm" src="https://cloud.githubusercontent.com/assets/2575027/14539621/22563c30-024f-11e6-95f8-9b8271621c0b.png">


Before this commit, the system was scheduling pickups at least a week in
advance.

This commit reworks the scheduler to schedule pickups for the _next_
occurrence of a given day.

Scheduling pickups remains idempotent.