### PR TITLE
Display Donations and Statuses for a Zipcode

### DIFF
--- a/app/models/scheduled_pickup.rb
+++ b/app/models/scheduled_pickup.rb
@@ -1,7 +1,9 @@
 class ScheduledPickup < ActiveRecord::Base
   HOURS_IN_ADVANCE_FOR_CONFIRMATION = 48
 
-  belongs_to :zone
+  belongs_to :zone, touch: true
+
+  has_many :donations, dependent: :destroy
 
   validates :zone, presence: true
   validates :end_at, presence: true

--- a/app/views/scheduled_pickups/_donation.html.erb
+++ b/app/views/scheduled_pickups/_donation.html.erb
@@ -1,0 +1,4 @@
+<tr>
+  <td><%= donation.donor.name %></td>
+  <td><%= label_for_donation(donation) %></td>
+</tr>

--- a/app/views/scheduled_pickups/_donations.html.erb
+++ b/app/views/scheduled_pickups/_donations.html.erb
@@ -1,0 +1,21 @@
+<h2 class="section-label"><%= t(".header") %></h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>
+        <%= t(".columns.name") %>
+      </th>
+      <th>
+        <%= t(".columns.status", date: l(scheduled_pickup.start_at.to_date)) %>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render(
+      partial: "scheduled_pickups/donation",
+      collection: scheduled_pickup.donations.includes(:donor),
+      as: :donation,
+    ) %>
+  </tbody>
+</table>

--- a/app/views/scheduled_pickups/show.html.erb
+++ b/app/views/scheduled_pickups/show.html.erb
@@ -27,23 +27,7 @@
   </section>
 
   <section class="zipcode-content-section">
-    <h2 class="section-label"><%= t(".suppliers") %></h2>
-    <table>
-      <thead>
-        <tr>
-          <th>Name</th>
-          <th>Donation Status for 10/20/15</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @scheduled_pickup.users.each do |user| %>
-          <tr>
-            <td><%= user.name %></td>
-            <td>Donating</td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <%= render("scheduled_pickups/donations", scheduled_pickup: @scheduled_pickup) %>
 
     <div class="supplier-map">
       <h2 class="section-label">Map</h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,7 +79,7 @@ en:
     statuses:
       confirmed: "Donating"
       declined: "Not Donating"
-      pending: "Pending"
+      pending: "Unknown"
     update:
       success: "Donation updated."
 
@@ -132,8 +132,12 @@ en:
         header: "Scheduled Confirmation Time"
         time: "Confirmations will be requested before %{time}"
       edit: "Edit"
-      suppliers: "Suppliers"
       time: "Scheduled Pickup Time"
+    donations:
+      header: "Donations"
+      columns:
+        name: "Supplier"
+        status: "Donation Status for %{date}"
     update:
       success: "The pickup has been rescheduled."
 

--- a/spec/features/admin_views_scheduled_pickup_spec.rb
+++ b/spec/features/admin_views_scheduled_pickup_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 require "rake"
 
-feature "Admin views pickup time" do
-  scenario "generated weekly" do
+feature "Admin views scheduled pickup" do
+  scenario "scheduled by the system" do
     friday = thursday + 1.day
 
     Timecop.freeze(thursday) do
@@ -12,6 +12,8 @@ feature "Admin views pickup time" do
         end_hour: 15,
         weekday: friday.wday,
       )
+      location = create(:location, zone: zone)
+      donor = location.user
       schedule_pickups!
 
       view_zone(zone)
@@ -20,7 +22,20 @@ feature "Admin views pickup time" do
         to have_text("Friday April 15, 2016 between 1:00 pm and 3:00 pm")
       expect(page).
         to have_confirmation_time("Wednesday April 13, 2016 at 1:00 pm")
+      expect(page).to have_donation_row_for(donor)
+      expect(page).to have_status_column_for(friday)
     end
+  end
+
+  def have_donation_row_for(donor)
+    have_text donor.name
+  end
+
+  def have_status_column_for(day)
+    have_text t(
+      "scheduled_pickups.donations.columns.status",
+      date: l(day.to_date),
+    )
   end
 
   def have_confirmation_time(time)

--- a/spec/models/scheduled_pickup_spec.rb
+++ b/spec/models/scheduled_pickup_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 describe ScheduledPickup do
-  it { should belong_to(:zone) }
+  it { should belong_to(:zone).touch }
+
+  it { should have_many(:donations).dependent(:destroy) }
 
   it { should validate_presence_of(:zone) }
   it { should validate_presence_of(:end_at) }

--- a/spec/views/scheduled_pickups/_donation.html.erb_spec.rb
+++ b/spec/views/scheduled_pickups/_donation.html.erb_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe "scheduled_pickups/donation" do
+  it "displays Donation information" do
+    donation = build(:donation, :confirmed)
+    donor = donation.donor
+
+    render("scheduled_pickups/donation", donation: donation)
+
+    expect(rendered).to have_text(donor.name)
+    expect(rendered).to have_status_text(:confirmed)
+  end
+
+  def have_status_text(status)
+    have_text t("donations.statuses.#{status}")
+  end
+end


### PR DESCRIPTION
<img width="697" alt="screen shot 2016-04-14 at 3 21 27 pm" src="https://cloud.githubusercontent.com/assets/2575027/14540734/98773fae-0254-11e6-87c5-08d4234fbcd8.png">

https://trello.com/c/wkjp3Zhs

This commit introduces the `scheduled_pickups/donations` partial, which
renders a table of all donations (including the Donor name and status).
