### PR TITLE
Reschedule Future Pickups

### DIFF
--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -3,8 +3,12 @@ class ZonesController < ApplicationController
     @zones = Zone.all
   end
 
+  def edit
+    @zone = find_zone
+  end
+
   def show
-    @zone = Zone.find_by!(zipcode: params[:id])
+    @zone = find_zone
 
     if current_scheduled_pickup.present?
       redirect_to zone_scheduled_pickup_url(
@@ -26,11 +30,23 @@ class ZonesController < ApplicationController
     end
   end
 
+  def update
+    @zone = find_zone
+
+    @zone.update!(zone_params)
+
+    redirect_to @zone, flash: { success: t(".success") }
+  end
+
   def new
     @zone = Zone.new
   end
 
   private
+
+  def find_zone
+    Zone.find_by!(zipcode: params[:id])
+  end
 
   def current_scheduled_pickup
     @zone.current_scheduled_pickup

--- a/app/models/scheduled_pickup.rb
+++ b/app/models/scheduled_pickup.rb
@@ -11,8 +11,6 @@ class ScheduledPickup < ActiveRecord::Base
   validates :end_at, presence: true
   validates :start_at, presence: true
 
-  delegate :zipcode, to: :zone
-
   def self.current
     where("start_at >= ?", Time.current.beginning_of_day)
   end

--- a/app/views/scheduled_pickups/_zone.html.erb
+++ b/app/views/scheduled_pickups/_zone.html.erb
@@ -1,0 +1,7 @@
+<header class="zipcode-header" data-role="zone">
+  <h2><%= zone.zipcode %></h2>
+
+  <%= link_to edit_zone_path(zone), class: "zipcode-activation-status" do %>
+    <%= t(".edit") %>
+  <% end %>
+</header>

--- a/app/views/scheduled_pickups/show.html.erb
+++ b/app/views/scheduled_pickups/show.html.erb
@@ -1,10 +1,7 @@
 <div class="content-wrapper-narrow content-container">
-  <header class="zipcode-header">
-    <h2><%= @scheduled_pickup.zipcode %></h2>
-    <span class="zipcode-activation-status">Active</span>
-  </header>
+  <%= render("scheduled_pickups/zone", zone: @scheduled_pickup.zone) %>
 
-  <section class="zipcode-content-section">
+  <section class="zipcode-content-section" data-role="pickup-time">
     <h2 class="section-label"><%= t(".time") %></h2>
     <span><%= @scheduled_pickup.time_range %></span>
 

--- a/app/views/zones/_form.html.erb
+++ b/app/views/zones/_form.html.erb
@@ -2,27 +2,7 @@
   <div class="form-container__body">
     <p><%= t("zones.new.prompt") %></p>
     <%= f.input :zipcode %>
-    <%= f.input(
-      :weekday,
-      collection: Weekday.all,
-      label_method: :label,
-      value_method: :value,
-      wrapper_html: { class: "label-input-group" },
-    ) %>
-    <%= f.input(
-      :start_hour,
-      collection: Hour.all,
-      label_method: :label,
-      value_method: :value,
-      wrapper_html: { class: "label-input-group" },
-    ) %>
-    <%= f.input(
-      :end_hour,
-      collection: Hour.all,
-      label_method: :label,
-      value_method: :value,
-      wrapper_html: { class: "label-input-group" },
-    ) %>
+    <%= render("zones/time_fields", f: f) %>
   </div>
   <footer class="form-container__footer">
     <%= f.submit %>

--- a/app/views/zones/_time_fields.html.erb
+++ b/app/views/zones/_time_fields.html.erb
@@ -1,0 +1,21 @@
+<%= f.input(
+  :weekday,
+  collection: Weekday.all,
+  label_method: :label,
+  value_method: :value,
+  wrapper_html: { class: "label-input-group" },
+) %>
+<%= f.input(
+  :start_hour,
+  collection: Hour.all,
+  label_method: :label,
+  value_method: :value,
+  wrapper_html: { class: "label-input-group" },
+) %>
+<%= f.input(
+  :end_hour,
+  collection: Hour.all,
+  label_method: :label,
+  value_method: :value,
+  wrapper_html: { class: "label-input-group" },
+) %>

--- a/app/views/zones/edit.html.erb
+++ b/app/views/zones/edit.html.erb
@@ -1,0 +1,17 @@
+<section>
+  <div class="content-wrapper-narrow form-container">
+    <header class="form-container__header">
+      <h3><%= t(".header", zipcode: @zone.zipcode) %></h3>
+    </header>
+
+    <%= simple_form_for(@zone) do |f| %>
+      <div class="form-container__body">
+        <%= render("zones/time_fields", f: f) %>
+      </div>
+
+      <footer class="form-container__footer">
+        <%= f.submit %>
+      </footer>
+    <% end %>
+  </div>
+</section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -156,6 +156,8 @@ en:
       header: "Donations"
     update:
       success: "The pickup has been rescheduled."
+    zone:
+      edit: "Edit"
 
   registrations:
     form:
@@ -198,6 +200,8 @@ en:
     defaults:
       prompt:
         "Pickups for %{zipcode} are usually scheduled for %{day} between %{start} and %{end}"
+    edit:
+      header: "Edit %{zipcode}'s Pickup Schedule"
     index:
       active: "Active Zipcodes"
       inactive: "Inactive Zipcodes"
@@ -211,3 +215,5 @@ en:
 
     show:
       no_pickup: "There are no pickups scheduled for this week."
+    update:
+      success: "Future pickups for this zipcode have been rescheduled."

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -20,6 +20,7 @@ en:
         create: "Tell me when you launch!"
       zone:
         create: "Create Zipcode"
+        update: "Save"
 
   simple_form:
     "yes": 'Yes'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   get "/pages/*id" => 'pages#show', as: :page, format: false
 
   constraints Clearance::Constraints::SignedIn.new(&:admin?) do
-    resources :zones, only: [:create, :index, :new, :show] do
+    resources :zones, only: [:create, :index, :new, :show, :edit, :update] do
       resources(
         :scheduled_pickups,
         path: :donations,

--- a/spec/features/admin_updates_scheduled_pickup_time_spec.rb
+++ b/spec/features/admin_updates_scheduled_pickup_time_spec.rb
@@ -30,7 +30,9 @@ feature "Admin updates schedule pickup time" do
   end
 
   def update_current_scheduled_pickup(start_at:)
-    click_on t("scheduled_pickups.show.edit")
+    within "[data-role=pickup-time]" do
+      click_on t("scheduled_pickups.show.edit")
+    end
 
     fill_form_and_submit(
       :scheduled_pickup,

--- a/spec/features/admin_updates_zone_pickup_time_range_spec.rb
+++ b/spec/features/admin_updates_zone_pickup_time_range_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+feature "Admin updates zone pickup time range" do
+  scenario "from the Zone page" do
+    zone = create_zone(
+      :with_scheduled_pickups,
+      start_hour: noon,
+      end_hour: one_pm,
+      weekday: thursday,
+    )
+
+    visit zone_path(zone, as: create(:admin))
+    update_zone(
+      start_hour: eight_am,
+      end_hour: nine_pm,
+      weekday: friday,
+    )
+
+    expect(page).to have_success_flash
+    expect(zone.reload).to be_scheduled_for(
+      start_hour: eight_am,
+      end_hour: nine_pm,
+      weekday: friday,
+    )
+  end
+
+  def be_scheduled_for(attributes)
+    have_attributes(attributes.transform_values(&:value))
+  end
+
+  def create_zone(*traits, **attributes)
+    create(:zone, *traits, attributes.transform_values(&:value))
+  end
+
+  def have_success_flash
+    have_text t("zones.update.success")
+  end
+
+  def update_zone(attributes)
+    within "[data-role=zone]" do
+      click_on t("scheduled_pickups.zone.edit")
+    end
+
+    fill_form_and_submit(:zone, :edit, attributes.transform_values(&:label))
+  end
+
+  def noon
+    Hour.find(11)
+  end
+
+  def one_pm
+    Hour.find(12)
+  end
+
+  def eight_am
+    Hour.find(7)
+  end
+
+  def nine_pm
+    Hour.find(20)
+  end
+
+  def thursday
+    Weekday.find(5)
+  end
+
+  def friday
+    Weekday.find(6)
+  end
+end

--- a/spec/models/scheduled_pickup_spec.rb
+++ b/spec/models/scheduled_pickup_spec.rb
@@ -9,8 +9,6 @@ describe ScheduledPickup do
   it { should validate_presence_of(:end_at) }
   it { should validate_presence_of(:start_at) }
 
-  it { should delegate_method(:zipcode).to(:zone) }
-
   describe ".current" do
     it "includes scheduled pickups from today and onward" do
       _yesterday_at_noon = create_scheduled_pickup(yesterday + 12.hours)


### PR DESCRIPTION
https://trello.com/c/DfprJzN7

This commit implements a `zones#edit` page for admins to reschedule
future pickups for different days of the week of time ranges throughout
the day.