### PR TITLE
BUG: Fix scheduling bug

### DIFF
--- a/app/models/pickup_scheduler.rb
+++ b/app/models/pickup_scheduler.rb
@@ -4,11 +4,9 @@ class PickupScheduler
   end
 
   def schedule!
-    if current_scheduled_pickup.nil?
-      ActiveRecord::Base.transaction do
-        scheduled_pickup.save!
-        enroll_donors!
-      end
+    ActiveRecord::Base.transaction do
+      scheduled_pickup.save!
+      enroll_donors!
     end
   end
 

--- a/spec/models/pickup_scheduler_spec.rb
+++ b/spec/models/pickup_scheduler_spec.rb
@@ -51,6 +51,21 @@ describe PickupScheduler do
         expect(ScheduledPickup.count).to eq(1)
       end
     end
+
+    it "creates Donations for the week" do
+      Timecop.freeze(thursday) do
+        scheduled_pickup = create(:scheduled_pickup)
+        zone = scheduled_pickup.zone
+        location = create(:location, zipcode: zone.zipcode)
+        scheduler = PickupScheduler.new(zone)
+
+        scheduler.schedule!
+
+        expect(location.donations.last).to have_attributes(
+          scheduled_pickup: scheduled_pickup,
+        )
+      end
+    end
   end
 
   it "enrolls Donors in the Zone" do


### PR DESCRIPTION
Pickup Scheduling wouldn't take new donors into account if a pickup had
been scheduled in the future.

This commit adds coverage that exposes the buggy behavior.