### PR TITLE
Extract Capybara helpers

### DIFF
--- a/spec/features/admin_deletes_admin_spec.rb
+++ b/spec/features/admin_deletes_admin_spec.rb
@@ -5,26 +5,18 @@ feature "Admin deletes admin" do
     to_be_deleted = create(:admin, name: "To Be Deleted")
 
     visit_users_page_as_admin
-    within_admin_row(to_be_deleted) do
+    within_record(to_be_deleted) do
       click_on t("users.delete.text")
     end
 
     expect(page).to have_success_flash(to_be_deleted)
-    within_admin_rows do
+    within_role :admins do
       expect(page).not_to have_user(to_be_deleted)
     end
   end
 
   def have_success_flash(admin)
     have_text t("users.destroy.success", name: admin.name)
-  end
-
-  def within_admin_rows(&block)
-    within("[data-role=admins]", &block)
-  end
-
-  def within_admin_row(admin, &block)
-    within("#user_#{admin.id}", &block)
   end
 
   def have_user(user)

--- a/spec/features/admin_deletes_admin_spec.rb
+++ b/spec/features/admin_deletes_admin_spec.rb
@@ -11,16 +11,12 @@ feature "Admin deletes admin" do
 
     expect(page).to have_success_flash(to_be_deleted)
     within_role :admins do
-      expect(page).not_to have_user(to_be_deleted)
+      expect(page).not_to have_name(to_be_deleted)
     end
   end
 
   def have_success_flash(admin)
     have_text t("users.destroy.success", name: admin.name)
-  end
-
-  def have_user(user)
-    have_text(user.name)
   end
 
   def visit_users_page_as_admin

--- a/spec/features/admin_updates_scheduled_pickup_time_spec.rb
+++ b/spec/features/admin_updates_scheduled_pickup_time_spec.rb
@@ -30,7 +30,7 @@ feature "Admin updates schedule pickup time" do
   end
 
   def update_current_scheduled_pickup(start_at:)
-    within "[data-role=pickup-time]" do
+    within_role "pickup-time" do
       click_on t("scheduled_pickups.show.edit")
     end
 

--- a/spec/features/admin_updates_zone_pickup_time_range_spec.rb
+++ b/spec/features/admin_updates_zone_pickup_time_range_spec.rb
@@ -37,7 +37,7 @@ feature "Admin updates zone pickup time range" do
   end
 
   def update_zone(attributes)
-    within "[data-role=zone]" do
+    within_role :zone do
       click_on t("scheduled_pickups.zone.edit")
     end
 

--- a/spec/features/admin_views_scheduled_pickup_spec.rb
+++ b/spec/features/admin_views_scheduled_pickup_spec.rb
@@ -28,7 +28,7 @@ feature "Admin views scheduled pickup" do
   end
 
   def have_donation_row_for(donor)
-    have_text donor.name
+    have_name(donor)
   end
 
   def have_status_column_for(day)

--- a/spec/features/admin_views_users_spec.rb
+++ b/spec/features/admin_views_users_spec.rb
@@ -8,19 +8,15 @@ feature "Admin views users" do
 
     visit_users_page(as: admin)
 
-    within_user_group :admins do
+    within_role :admins do
       expect(page).to have_user(admin)
     end
-    within_user_group :donors do
+    within_role :donors do
       expect(page).to have_user(donor)
     end
-    within_user_group :cyclists do
+    within_role :cyclists do
       expect(page).to have_user(cyclist)
     end
-  end
-
-  def within_user_group(group, &block)
-    within("[data-role=#{group}]", &block)
   end
 
   def have_user(user)

--- a/spec/features/admin_views_users_spec.rb
+++ b/spec/features/admin_views_users_spec.rb
@@ -9,18 +9,14 @@ feature "Admin views users" do
     visit_users_page(as: admin)
 
     within_role :admins do
-      expect(page).to have_user(admin)
+      expect(page).to have_name(admin)
     end
     within_role :donors do
-      expect(page).to have_user(donor)
+      expect(page).to have_name(donor)
     end
     within_role :cyclists do
-      expect(page).to have_user(cyclist)
+      expect(page).to have_name(cyclist)
     end
-  end
-
-  def have_user(user)
-    have_text user.name
   end
 
   def visit_users_page(as:)

--- a/spec/features/cyclist_views_pickup_checklist_spec.rb
+++ b/spec/features/cyclist_views_pickup_checklist_spec.rb
@@ -18,6 +18,6 @@ feature "Cyclist views pickup checklist" do
   end
 
   def have_donor_for(donation)
-    have_text(donation.donor.name)
+    have_name(donation.donor)
   end
 end

--- a/spec/support/features/finders.rb
+++ b/spec/support/features/finders.rb
@@ -1,0 +1,11 @@
+module Features
+  include ActionView::RecordIdentifier
+
+  def within_role(role, &block)
+    within(%{[data-role="#{role}"]}, &block)
+  end
+
+  def within_record(record, &block)
+    within("##{dom_id(record)}", &block)
+  end
+end

--- a/spec/support/features/matchers.rb
+++ b/spec/support/features/matchers.rb
@@ -1,0 +1,9 @@
+module Features
+  def have_name(record)
+    if record.respond_to?(:name)
+      have_text(record.name.to_s)
+    else
+      have_text(record.to_s)
+    end
+  end
+end


### PR DESCRIPTION
**Extract `within_{record,role}` spec helper**

Extract block helpers to scope Capybara actions to particular roles and
records.

**Extract `have_name` feature spec matcher**

Extracts the `have_name` matcher, which will call and check for the
presence of `#name` when available.