### PR TITLE
Promote donors to admins, demote admins to donors

### DIFF
--- a/app/controllers/promotions_controller.rb
+++ b/app/controllers/promotions_controller.rb
@@ -1,0 +1,19 @@
+class PromotionsController < ApplicationController
+  def create
+    user.update!(admin: true)
+
+    redirect_to(users_url, flash: { success: t(".success", name: user.name) })
+  end
+
+  def destroy
+    user.update!(admin: false)
+
+    redirect_to(users_url, flash: { success: t(".success", name: user.name) })
+  end
+
+  private
+
+  def user
+    @user ||= User.find(params[:user_id])
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,5 @@
+module UsersHelper
+  def render_user_rows(users, &block)
+    render(layout: "users/row", locals: { users: users }, &block)
+  end
+end

--- a/app/views/users/_admins.html.erb
+++ b/app/views/users/_admins.html.erb
@@ -9,6 +9,7 @@
   </thead>
   <tbody>
     <%= render_user_rows(admins) do |admin| %>
+      <%= render("users/demote", user: admin) %>
       <%= render("users/delete", user: admin) %>
     <% end %>
   </tbody>

--- a/app/views/users/_admins.html.erb
+++ b/app/views/users/_admins.html.erb
@@ -8,13 +8,8 @@
     </tr>
   </thead>
   <tbody>
-    <% admins.each do |admin| %>
-      <%= content_tag_for(:tr, admin) do %>
-        <td><%= admin.name %></td>
-        <td class="table-actions">
-          <%= render("users/delete", user: admin) %>
-        </td>
-      <% end %>
+    <%= render_user_rows(admins) do |admin| %>
+      <%= render("users/delete", user: admin) %>
     <% end %>
   </tbody>
   <tfoot>

--- a/app/views/users/_cyclists.html.erb
+++ b/app/views/users/_cyclists.html.erb
@@ -8,11 +8,8 @@
     </tr>
   </thead>
   <tbody>
-    <% cyclists.each do |cyclist| %>
-      <tr>
-        <td><%= cyclist.name %></td>
-        <td class="table-actions"><a href="" class="table-link table-delete">Delete</a></td>
-      </tr>
+    <%= render_user_rows(cyclists) do |cyclist| %>
+      <a href="" class="table-link table-delete">Delete</a>
     <% end %>
   </tbody>
   <tfoot>
@@ -22,6 +19,7 @@
           <%= t(".new") %>
         <% end %>
       </td>
+      <td></td>
     </tr>
   </tfoot>
 </table>

--- a/app/views/users/_demote.html.erb
+++ b/app/views/users/_demote.html.erb
@@ -1,0 +1,10 @@
+<%= button_to(
+  user_promotion_path(user),
+  class: "table-link table-delete",
+  method: :delete,
+  data: {
+    confirm: t(".confirm"),
+  }
+) do %>
+  <%= t(".text") %>
+<% end %>

--- a/app/views/users/_donors.html.erb
+++ b/app/views/users/_donors.html.erb
@@ -7,13 +7,10 @@
     </tr>
   </thead>
   <tbody>
-    <% donors.each do |donor| %>
-      <td><%= donor.name %></td>
-      <td class="table-actions">
-        <a href="" class="table-link">Profile</a>
-        <a href="" class="table-link">Pickup History</a>
-        <a href="" class="table-link table-delete">Delete</a>
-      </td>
+    <%= render_user_rows(donors) do |donor| %>
+      <a href="" class="table-link">Profile</a>
+      <a href="" class="table-link">Pickup History</a>
+      <a href="" class="table-link table-delete">Delete</a>
     <% end %>
   </tbody>
 </table>

--- a/app/views/users/_donors.html.erb
+++ b/app/views/users/_donors.html.erb
@@ -8,6 +8,8 @@
   </thead>
   <tbody>
     <%= render_user_rows(donors) do |donor| %>
+      <%= render("users/promote", user: donor) %>
+
       <a href="" class="table-link">Profile</a>
       <a href="" class="table-link">Pickup History</a>
       <a href="" class="table-link table-delete">Delete</a>

--- a/app/views/users/_promote.html.erb
+++ b/app/views/users/_promote.html.erb
@@ -1,0 +1,10 @@
+<%= button_to(
+  user_promotion_path(user),
+  class: "table-link",
+  method: :post,
+  data: {
+    confirm: t(".confirm"),
+  }
+) do %>
+  <%= t(".text") %>
+<% end %>

--- a/app/views/users/_row.html.erb
+++ b/app/views/users/_row.html.erb
@@ -1,0 +1,8 @@
+<% users.each do |user| %>
+  <%= content_tag_for(:tr, user) do %>
+    <td><%= user.name %></td>
+    <td class="table-actions">
+      <%= yield(user) %>
+    </td>
+  <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,12 @@ en:
       pickup: "Pickup Info"
       edit: "Edit Personal Info"
 
+  promotions:
+    create:
+      success: "%{name} has been promoted to an administrator."
+    destroy:
+      success: "%{name} is no longer an administrator."
+
   scheduled_pickups:
     edit:
       header: "Reschedule this week's pickup"
@@ -220,12 +226,18 @@ en:
     delete:
       confirm: "Are you sure you want to delete %{name}?"
       text: "Delete"
+    demote:
+      confirm: "Are you sure you want to revoke this administrator?"
+      text: "Revoke"
     destroy:
       success: "Successfully deleted %{name}."
     donors:
       columns:
         name: "Name"
       header: "Suppliers"
+    promote:
+      confirm: "Are you sure you want to promote this user?"
+      text: "Make admin"
 
   validations:
     accepted: "must be checked"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,9 @@ Rails.application.routes.draw do
 
   constraints Clearance::Constraints::SignedIn.new(&:admin?) do
     resources :cyclist_invitations, only: [:new, :create, :show]
-    resources :users, only: [:index, :destroy]
+    resources :users, only: [:index, :destroy] do
+      resource :promotion, only: [:create, :destroy]
+    end
     resources :zones, only: [:create, :index, :new, :show, :edit, :update] do
       resources(
         :scheduled_pickups,

--- a/spec/features/admin_demotes_admin_to_donor_account_spec.rb
+++ b/spec/features/admin_demotes_admin_to_donor_account_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+feature "Admin demotes admin to donor account" do
+  scenario "from the Users list" do
+    admin = create(:donor, admin: true)
+
+    visit_users_page
+    demote_user(admin)
+
+    within_role :donors do
+      expect(page).to have_name(admin)
+      expect(page).to have_promote_button
+    end
+    expect(page).to have_success_flash(admin)
+  end
+
+  def have_success_flash(user)
+    have_text t("promotions.destroy.success", name: user.name)
+  end
+
+  def have_promote_button
+    have_text t("users.promote.text")
+  end
+
+  def visit_users_page
+    visit users_path(as: create(:admin))
+  end
+
+  def demote_user(user)
+    within_record(user) do
+      click_on t("users.demote.text")
+    end
+  end
+end

--- a/spec/features/admin_promotes_donor_to_admin_account_spec.rb
+++ b/spec/features/admin_promotes_donor_to_admin_account_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+feature "Admin promotes donor to admin account" do
+  scenario "from the Users list" do
+    donor = create(:donor)
+
+    visit_users_page
+    promote_user(donor)
+
+    within_role :admins do
+      expect(page).to have_name(donor)
+      expect(page).to have_demote_button
+    end
+    expect(page).to have_success_flash(donor)
+  end
+
+  def have_success_flash(donor)
+    have_text t("promotions.create.success", name: donor.name)
+  end
+
+  def have_demote_button
+    have_text t("users.demote.text")
+  end
+
+  def visit_users_page
+    visit users_path(as: create(:admin))
+  end
+
+  def promote_user(user)
+    within_record(user) do
+      click_on t("users.promote.text")
+    end
+  end
+end


### PR DESCRIPTION
**Promote donors to admins, demote admins to donors**

https://trello.com/c/fHWf9G5o

When managing users, administrators can promote donor users to
administrators.

If an promotion is accidentally given, or if an administrator will no
longer be administrating, their administrative powers can be revoked.

**Extract `render_user_rows` helper and partial**