### PR TITLE
Deactivate cyclist accounts

### DIFF
--- a/app/models/active_guard.rb
+++ b/app/models/active_guard.rb
@@ -1,0 +1,9 @@
+class ActiveGuard < Clearance::SignInGuard
+  def call
+    if current_user.deleted?
+      failure(I18n.t("validations.deactivated"))
+    else
+      next_guard
+    end
+  end
+end

--- a/app/views/users/_cyclists.html.erb
+++ b/app/views/users/_cyclists.html.erb
@@ -9,7 +9,7 @@
   </thead>
   <tbody>
     <%= render_user_rows(cyclists) do |cyclist| %>
-      <a href="" class="table-link table-delete">Delete</a>
+      <%= render("users/delete", user: cyclist) %>
     <% end %>
   </tbody>
   <tfoot>

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -2,4 +2,5 @@ Clearance.configure do |config|
   config.allow_sign_up = false
   config.mailer_sender = "team@freshfoodconnect.org"
   config.routes = false
+  config.sign_in_guards = [ActiveGuard]
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -241,6 +241,7 @@ en:
 
   validations:
     accepted: "must be checked"
+    deactivated: "This account has been deactivated."
     unsupported: "We're sorry, our service is not available in %{zipcode} at this time."
 
   zones:

--- a/spec/features/admin_deletes_cyclist_account_spec.rb
+++ b/spec/features/admin_deletes_cyclist_account_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+feature "Admin deletes cyclist account" do
+  scenario "from the Users list" do
+    ensure_zone_exists!
+    cyclist = create(:cyclist)
+
+    visit_users_page
+    delete_user(cyclist)
+
+    within_role :cyclists do
+      expect(page).not_to have_name(cyclist)
+    end
+    expect(page).to have_success_flash(cyclist)
+  end
+
+  def have_success_flash(user)
+    have_text t("users.destroy.success", name: user.name)
+  end
+
+  def visit_users_page
+    visit users_path(as: create(:admin))
+  end
+
+  def delete_user(user)
+    within_record(user) do
+      click_on t("users.delete.text")
+    end
+  end
+
+  def ensure_zone_exists!
+    create(:zone)
+  end
+end

--- a/spec/features/deactivated_cyclist_cannot_sign_in_spec.rb
+++ b/spec/features/deactivated_cyclist_cannot_sign_in_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+feature "Deactivated cyclist cannot sign in" do
+  scenario "when deleted by administrator" do
+    cyclist = create(:cyclist, :deleted, assigned_zone: create(:zone))
+
+    sign_in_as(cyclist)
+
+    expect(page).to have_deactivated_error
+  end
+
+  def have_deactivated_error
+    have_text t("validations.deactivated")
+  end
+end


### PR DESCRIPTION
https://trello.com/c/7F2v8iuM

When a volunteer cyclist is no longer working for the service,
deactivate their account so they no longer have access to sensitive
information.