### PR TITLE
Add coverage for Clearance Guard bug

### DIFF
--- a/app/models/active_guard.rb
+++ b/app/models/active_guard.rb
@@ -1,6 +1,6 @@
 class ActiveGuard < Clearance::SignInGuard
   def call
-    if current_user.deleted?
+    if signed_in? && current_user.deleted?
       failure(I18n.t("validations.deactivated"))
     else
       next_guard

--- a/spec/features/donor_signs_in_spec.rb
+++ b/spec/features/donor_signs_in_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+feature "Donor signs in" do
+  scenario "after registering" do
+    donor = create(:donor)
+
+    sign_in_as(donor)
+
+    expect(page).to be_profile_page_for(donor)
+  end
+
+  scenario "when not registered" do
+    donor = build_stubbed(:donor)
+
+    sign_in_as(donor)
+
+    expect(page).to be_sign_in_page
+  end
+
+  def be_profile_page_for(donor)
+    have_name(donor.name)
+  end
+
+  def be_sign_in_page
+    have_text t("flashes.failure_after_create")
+  end
+end


### PR DESCRIPTION
When a non-existent user attempts signing in, `ActiveGuard#current_user`
is `nil`.

This adds Capybara coverage to prevent this bug from resurfacing.