### PR TITLE
Remove `Add Admin` link

### DIFF
--- a/app/views/users/_admins.html.erb
+++ b/app/views/users/_admins.html.erb
@@ -13,10 +13,4 @@
       <%= render("users/delete", user: admin) %>
     <% end %>
   </tbody>
-  <tfoot>
-    <tr>
-      <td><a href="" class="table-link">+ Add Admin</a></td>
-      <td></td>
-    </tr>
-  </tfoot>
 </table>


### PR DESCRIPTION
The current flow enables "promoting" administrators from the list of
registered donors.

For now, this link isn't necessary.