### PR TITLE
Expose `rake locations:geocode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Each night, the scheduler will run the following tasks:
   associated with `ScheduledPickup`s scheduled to occur within the next `48`
   hours.
 
+## Geocoding Locations
+
+To geocode all locations that are missing `latitude` or `longitude` values:
+
+```bash
+$ rake locations:geocode
+```
+
 [staging]: https://dashboard.heroku.com/apps/freshfoodconnect-staging
 [production]: https://dashboard.heroku.com/apps/freshfoodconnect-production
 [scheduler]: https://elements.heroku.com/addons/scheduler

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -27,6 +27,10 @@ class Location < ActiveRecord::Base
   validates :zipcode, presence: true, zipcode: { country_code: :us }
   validates :zone, presence: true
 
+  def self.not_geocoded
+    where("latitude IS NULL OR longitude IS NULL")
+  end
+
   def zipcode=(zipcode)
     super(zipcode.to_s.strip)
   end

--- a/bin/setup
+++ b/bin/setup
@@ -17,8 +17,9 @@ bin/rake dev:prime pickups:schedule
 mkdir -p .git/safe
 
 # Only if this isn't CI
-# if [ -z "$CI" ]; then
-# fi
+if [ -z "$CI" ]; then
+ bin/rake locations:geocode
+fi
 
 if heroku join --app freshfoodconnect-staging &> /dev/null; then
   git remote add staging git@heroku.com:freshfoodconnect-staging.git || true

--- a/lib/tasks/locations.rake
+++ b/lib/tasks/locations.rake
@@ -1,0 +1,8 @@
+namespace :locations do
+  desc "Geocode all missing locations"
+  task geocode: :environment do
+    Location.not_geocoded.each do |location|
+      GeocodeJob.perform_now(location)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -51,12 +51,23 @@ FactoryGirl.define do
 
     residence
     grown_on_site
+    not_geocoded
     user
 
     supported
 
+    trait :geocoded do
+      latitude 40
+      longitude 60
+    end
+
     trait :grown_on_site do
       grown_on_site true
+    end
+
+    trait :not_geocoded do
+      latitude nil
+      longitude nil
     end
 
     trait :residence do

--- a/spec/features/donor_edits_location_spec.rb
+++ b/spec/features/donor_edits_location_spec.rb
@@ -37,15 +37,6 @@ feature "Donor edits location" do
     end
   end
 
-  def stub_geocoding_for(address, latitude:, longitude:)
-    Geocoder::Lookup::Test.add_stub(
-      address, [{
-        "latitude" => latitude,
-        "longitude" => longitude,
-      }],
-    )
-  end
-
   def have_supported_zipcode_text(zipcode)
     have_text t("profiles.show.supported", zipcode: zipcode)
   end

--- a/spec/features/system_geocodes_locations_spec.rb
+++ b/spec/features/system_geocodes_locations_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+require "rake"
+
+feature "System geocodes locations" do
+  scenario "with `rake locations:geocode`" do
+    existing_coordinates = {
+      latitude: 5.0,
+      longitude: 6.0,
+    }
+    new_coordinates = {
+      latitude: -1.0,
+      longitude: 1.0,
+    }
+    not_geocoded = create(:location, :supported, :not_geocoded)
+    geocoded = create(:location, :geocoded, :supported, existing_coordinates)
+    stub_geocode(not_geocoded, with: new_coordinates)
+    stub_geocode(geocoded, with: change_coordinates(existing_coordinates))
+
+    geocode_locations!
+
+    expect(not_geocoded.reload).to be_geocoded_with(new_coordinates)
+    expect(geocoded.reload).to be_geocoded_with(existing_coordinates)
+  end
+
+  def stub_geocode(location, with:)
+    stub_geocoding_for([location.address, location.zipcode].join(" "), with)
+  end
+
+  def change_coordinates(coordinates)
+    {
+      latitude: coordinates[:latitude] + 1.0,
+      longitude: coordinates[:longitude] + 1.0,
+    }
+  end
+
+  def be_geocoded_with(coordinates)
+    have_attributes(coordinates.transform_values { |l| BigDecimal.new(l.to_s) })
+  end
+
+  def geocode_locations!
+    Rake::Task["locations:geocode"].invoke
+  end
+
+  before :all do
+    Rake.application.rake_require "tasks/locations"
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -28,6 +28,29 @@ describe Location do
   it { should validate_numericality_of(:longitude).is_less_than_or_equal_to(180) }
   it { should validate_numericality_of(:longitude).allow_nil }
 
+  describe ".not_geocoded" do
+    it "includes Location records without latitude or longitude values" do
+      create(:location, latitude: 1, longitude: 1)
+      create(:location, latitude: nil, longitude: 1)
+      create(:location, latitude: 1, longitude: nil)
+      create(:location, latitude: nil, longitude: nil)
+
+      not_geocoded = Location.not_geocoded
+      locations = not_geocoded.map do |location|
+        {
+          latitude: location.latitude,
+          longitude: location.longitude,
+        }
+      end
+
+      expect(locations).to match_array([
+        { latitude: nil, longitude: 1 },
+        { latitude: 1, longitude: nil },
+        { latitude: nil, longitude: nil },
+      ])
+    end
+  end
+
   describe "#zipcode=" do
     it "trims whitespace" do
       location = Location.new(zipcode: "    90210 ")

--- a/spec/support/features/locations.rb
+++ b/spec/support/features/locations.rb
@@ -1,0 +1,10 @@
+module Features
+  def stub_geocoding_for(address, latitude:, longitude:)
+    Geocoder::Lookup::Test.add_stub(
+      address, [{
+        "latitude" => latitude,
+        "longitude" => longitude,
+      }],
+    )
+  end
+end


### PR DESCRIPTION
During development bootstrapping (via `bin/setup`), geocode all
locations in need of geocoding.