### PR TITLE
Send cyclist invitation email

### DIFF
--- a/app/controllers/cyclist_invitations_controller.rb
+++ b/app/controllers/cyclist_invitations_controller.rb
@@ -24,7 +24,7 @@ class CyclistInvitationsController < ApplicationController
   end
 
   def find_user
-    User.find(params[:id])
+    User.cyclists.find(params[:id])
   end
 
   def build_user

--- a/app/models/cyclist_invitation.rb
+++ b/app/models/cyclist_invitation.rb
@@ -13,7 +13,22 @@ class CyclistInvitation < SimpleDelegator
     super(user)
   end
 
+  def save
+    super.tap do |saved|
+      if saved
+        user.forgot_password!
+        ClearanceMailer.change_password(user).deliver_later
+      end
+    end
+  end
+
   def to_model
     self
+  end
+
+  private
+
+  def user
+    __getobj__
   end
 end

--- a/app/views/cyclist_invitations/show.html.erb
+++ b/app/views/cyclist_invitations/show.html.erb
@@ -3,9 +3,19 @@
     <h2><%= t(".header", name: @cyclist_invitation.name) %></h2>
   </header>
 
-  <p><%= t(".instructions", email: @cyclist_invitation.email) %></p>
+  <p>
+    <%= t(
+      ".instructions",
+      email: @cyclist_invitation.email,
+      name: @cyclist_invitation.name,
+    ) %>
+  </p>
 
-  <%= link_to new_password_url do %>
-    <%= new_password_url %>
-  <% end %>
+  <p>
+    <%= t(".fallback") %>
+
+    <%= link_to new_password_url do %>
+      <%= new_password_url %>
+    <% end %>
+  <p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,13 +64,14 @@ en:
     new:
       header: "Invite a Cyclist"
     show:
-      header: "Cyclist: %{name}"
+      header: "New Cyclist profile created!"
       instructions:
         >
-        A cyclist account has been created for %{email}.
+          An email has been sent to %{name} at %{email} with instructions on how to set their password and finish creating their cyclist profile.
 
-        Please instruct the cyclist to visit the following link to reset their
-        password and gain access to the latest pickup checklist.
+      fallback:
+        >
+          If the new Cyclist does not receive the email, send them this link to reset the password manually:
 
   donations:
     confirm:

--- a/spec/features/admin_invites_cyclist_account_spec.rb
+++ b/spec/features/admin_invites_cyclist_account_spec.rb
@@ -23,6 +23,7 @@ feature "Admin creates cyclist account" do
   end
 
   def invite_cyclist(attributes)
+    create(:zone)
     visit users_path(as: create(:admin))
 
     click_on t("users.cyclists.new")

--- a/spec/models/cyclist_invitation_spec.rb
+++ b/spec/models/cyclist_invitation_spec.rb
@@ -7,12 +7,14 @@ describe CyclistInvitation do
         ensure_zone_exists!
         user = User.new(email: "cyclist@example.com")
         cyclist = CyclistInvitation.new(user)
+        password_reset_email = stub_password_reset_email_for(user)
 
         saved = cyclist.save
 
         expect(saved).to be true
         expect(user).to be_created_with(email: "cyclist@example.com")
         expect(cyclist).to be_created_with(email: "cyclist@example.com")
+        expect(password_reset_email).to be_sent
       end
     end
 
@@ -21,12 +23,28 @@ describe CyclistInvitation do
         ensure_zone_exists!
         user = User.new(email: nil)
         cyclist = CyclistInvitation.new(user)
+        password_reset_email = stub_password_reset_email_for(user)
 
         valid = cyclist.valid?
 
         expect(valid).to be false
         expect(cyclist.errors.keys).to include(:email)
+        expect(password_reset_email).not_to be_sent
       end
+    end
+
+    def stub_password_reset_email_for(user)
+      mail_stub = double(deliver_later: true)
+
+      allow(ClearanceMailer).
+        to receive(:change_password).
+        with(user).and_return(mail_stub)
+
+      mail_stub
+    end
+
+    def be_sent
+      have_received(:deliver_later)
     end
 
     def be_created_with(email:)


### PR DESCRIPTION

<img width="699" alt="screen shot 2016-04-21 at 4 31 51 pm" src="https://cloud.githubusercontent.com/assets/2575027/14724413/018989f4-07e4-11e6-9a28-4bee52167fdf.png">

https://trello.com/c/40G2fE31

When inviting a cyclist, schedule the password reset email to be sent to
the provided email address.

Additionally, this commit improves the cyclist invitation copy.