### PR TITLE
Forbid donors to sign up for an unsupported zip

### DIFF
--- a/app/controllers/pre_registrations_controller.rb
+++ b/app/controllers/pre_registrations_controller.rb
@@ -4,9 +4,9 @@ class PreRegistrationsController < ApplicationController
 
   def create
     if pre_registration.supported?
-      redirect_to new_registration_url(zipcode: pre_registration.zipcode)
+      redirect_to new_zone_registration_url(pre_registration.zipcode)
     else
-      redirect_to new_subscription_url(zipcode: pre_registration.zipcode)
+      redirect_to new_zone_subscription_url(pre_registration.zipcode)
     end
   end
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,11 +2,7 @@ class RegistrationsController < ApplicationController
   skip_before_action :require_login
 
   def new
-    if zipcode.present?
-      @registration = Registration.new(zipcode: zipcode)
-    else
-      redirect_to root_url
-    end
+    @registration = Registration.new(zipcode: zone.zipcode)
   end
 
   def create
@@ -23,8 +19,8 @@ class RegistrationsController < ApplicationController
 
   private
 
-  def zipcode
-    params[:zipcode]
+  def zone
+    Zone.find_by!(zipcode: params[:zone_id])
   end
 
   def build_registration
@@ -42,7 +38,7 @@ class RegistrationsController < ApplicationController
         :organic_growth_asserted,
         :password,
         :terms_and_conditions_accepted,
-        :zipcode,
-      )
+      ).
+      merge(zipcode: zone.zipcode)
   end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -2,10 +2,6 @@ class SubscriptionsController < ApplicationController
   skip_before_action :require_login
 
   def new
-    if zipcode.blank?
-      redirect_to root_url
-    end
-
     @subscription = Subscription.new(zipcode: zipcode)
   end
 
@@ -26,10 +22,13 @@ class SubscriptionsController < ApplicationController
   end
 
   def subscription_params
-    params.require(:subscription).permit(:email, :zipcode)
+    params.
+      require(:subscription).
+      permit(:email, :zipcode).
+      merge(zipcode: zipcode)
   end
 
   def zipcode
-    params[:zipcode]
+    params[:zone_id]
   end
 end

--- a/app/views/registrations/_form.html.erb
+++ b/app/views/registrations/_form.html.erb
@@ -1,9 +1,10 @@
-<%= simple_form_for registration do |f| %>
+<%= simple_form_for(
+  registration, url: zone_registrations_path(registration.zipcode),
+) do |f| %>
   <div class="form-container__body">
     <p><%= t(".prompt") %></p>
     <%= f.input :name, required: "true" %>
     <%= f.input :address, label: "Address for pickup", required: "true" %>
-    <%= f.input :zipcode, required: "true" %>
     <%= f.input :email, required: "true" %>
     <%= f.input :password, required: "true" %>
 

--- a/app/views/subscriptions/_form.html.erb
+++ b/app/views/subscriptions/_form.html.erb
@@ -1,9 +1,12 @@
-<%= simple_form_for subscription do |f| %>
+<%= simple_form_for(
+  subscription,
+  url: zone_subscriptions_path(subscription.zipcode),
+) do |f| %>
   <div class="form-container__body">
     <p><%= t(".prompt") %></p>
     <%= f.input :email %>
-    <%= f.input :zipcode %>
   </div>
+
   <footer class="form-container__footer">
     <%= f.submit %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,11 @@ Rails.application.routes.draw do
   end
   resource :location, only: [:update]
   resources :pre_registrations, only: [:create]
-  resources :registrations, only: [:create, :new]
-  resources :subscriptions, only: [:create, :new]
+
+  resources :zones, only: [] do
+    resources :registrations, only: [:create, :new]
+    resources :subscriptions, only: [:create, :new]
+  end
 
   resources :passwords, controller: "clearance/passwords", only: [:create, :new]
   resource :session, controller: "clearance/sessions", only: [:create]


### PR DESCRIPTION
https://trello.com/c/eIgrdBrn

This moves the `zipcode` value from the `?zipcode=` query parameter to a
dynamic `:zone_id` portion of the URL.

Additionally, when creating a `Registration`, the application will
ensure that the corresponding `Zone` record exists.