### PR TITLE
Configure Default `from` address for Mailers

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,7 @@ SECRET_KEY_BASE=development_secret
 EXECJS_RUNTIME=Node
 SMTP_ADDRESS=smtp.example.com
 SMTP_DOMAIN=example.com
+SMTP_FROM=team@freshfoodconnect.org
 SMTP_PASSWORD=password
 SMTP_USERNAME=username
 WEB_CONCURRENCY=1

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,3 @@
+class ApplicationMailer < ActionMailer::Base
+  default from: ENV.fetch("SMTP_FROM")
+end

--- a/app/mailers/donations_mailer.rb
+++ b/app/mailers/donations_mailer.rb
@@ -1,11 +1,10 @@
-class DonationsMailer < ActionMailer::Base
+class DonationsMailer < ApplicationMailer
   def request_confirmation(donation:)
     @confirmation = Confirmation.new(donation)
 
     mail(
       to: donation.donor.email,
       subject: t(".subject", range: @confirmation.time_range),
-      from: "support@freshfoodconnect.com",
     )
   end
 end

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -1,6 +1,6 @@
 Clearance.configure do |config|
   config.allow_sign_up = false
-  config.mailer_sender = "team@freshfoodconnect.org"
+  config.mailer_sender = ENV.fetch("SMTP_FROM")
   config.routes = false
   config.sign_in_guards = [ActiveGuard]
 end


### PR DESCRIPTION
https://trello.com/c/pUmNp6lv

Extracts `ApplicationMailer` for configuring defaults.

Configure Mailers to get `from` address from `SMTP_FROM` environment
variable.