### PR TITLE
Cleanup `/users` styles and links

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,7 @@ class User < ActiveRecord::Base
   end
 
   def self.donors
-    joins(:location).where(admin: false)
+    joins(:location)
   end
 
   def cyclist=(is_cyclist)

--- a/app/views/scheduled_pickups/_donation.html.erb
+++ b/app/views/scheduled_pickups/_donation.html.erb
@@ -1,4 +1,8 @@
 <tr>
-  <td><%= donation.donor.name %></td>
+  <td>
+    <%= link_to donor_path(donation.donor), class: "table-link" do %>
+      <%= donation.donor.name %>
+    <% end %>
+  </td>
   <td><%= label_for_donation(donation) %></td>
 </tr>

--- a/app/views/users/_cyclists.html.erb
+++ b/app/views/users/_cyclists.html.erb
@@ -9,12 +9,11 @@
   </thead>
   <tbody>
     <%= render_user_rows(cyclists) do |cyclist| %>
-      <td>
-        <%= link_to cyclist_invitation_path(cyclist) do %>
-          <%= cyclist.name %>
-        <% end %>
-      </td>
+      <td><%= cyclist.name %></td>
       <td class="table-actions">
+        <%= link_to cyclist_invitation_path(cyclist), class: "table-link" do %>
+          <%= t("users.cyclists.register") %>
+        <% end %>
         <%= render("users/delete", user: cyclist) %>
       </td>
     <% end %>

--- a/app/views/users/_donors.html.erb
+++ b/app/views/users/_donors.html.erb
@@ -12,7 +12,9 @@
       <td><%= donor.name %></td>
       <td><%= donor.address %> <%= donor.zipcode %></td>
       <td class="table-actions">
-        <%= render("users/promote", user: donor) %>
+        <% unless donor.admin? %>
+          <%= render("users/promote", user: donor) %>
+        <% end %>
 
         <%= link_to(donor_path(donor), class: "table-link")do %>
           <%= t("users.donors.history") %>

--- a/app/views/users/_promote.html.erb
+++ b/app/views/users/_promote.html.erb
@@ -4,6 +4,7 @@
   method: :post,
   data: {
     confirm: t(".confirm"),
+    role: "promote",
   }
 ) do %>
   <%= t(".text") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,9 +145,9 @@ en:
     destroy:
       success: "Donation pickup undone."
     statuses:
-      no_donation: "No Donation"
-      pending: "Pending"
-      success: "Picked Up"
+      no_donation: "Not donating"
+      pending: "Donating - Not yet picked up"
+      success: "Picked up"
     update:
       success: "Donation pickup confirmed."
 
@@ -236,7 +236,8 @@ en:
       columns:
         name: "Name"
       header: "Cyclists"
-      new: "+ Add Cyclist"
+      new: "+ Invite Cyclist"
+      register: "Register"
     delete:
       confirm: "Are you sure you want to delete %{name}?"
       text: "Delete"
@@ -253,7 +254,7 @@ en:
       history: "Donation History"
     promote:
       confirm: "Are you sure you want to promote this user?"
-      text: "Make admin"
+      text: "Make Admin"
 
   validations:
     accepted: "must be checked"

--- a/spec/features/admin_demotes_admin_to_donor_account_spec.rb
+++ b/spec/features/admin_demotes_admin_to_donor_account_spec.rb
@@ -27,8 +27,10 @@ feature "Admin demotes admin to donor account" do
   end
 
   def demote_user(user)
-    within_record(user) do
-      click_on t("users.demote.text")
+    within_role :admins do
+      within_record(user) do
+        click_on t("users.demote.text")
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,15 +57,15 @@ describe User do
   end
 
   describe ".donors" do
-    it "includes donors that are not administrators" do
+    it "includes donors" do
       donor = create(:donor, admin: false, name: "Donor")
-      create(:donor, admin: true, name: "Admin/Donor")
+      admin_donor = create(:donor, admin: true, name: "Admin/Donor")
       create(:admin, name: "Admin")
       create(:cyclist, name: "Cyclist")
 
       names = User.donors.pluck(:name)
 
-      expect(names).to eq([donor.name])
+      expect(names).to match_array([admin_donor, donor].map(&:name))
     end
   end
 

--- a/spec/views/users/_donors.html.erb_spec.rb
+++ b/spec/views/users/_donors.html.erb_spec.rb
@@ -13,11 +13,31 @@ describe "users/_donors" do
     expect(rendered).to have_text(donor.name)
     expect(rendered).to have_text(donor.address)
     expect(rendered).to have_text(donor.zipcode)
+    expect(rendered).to have_promote_button
   end
 
-  def build_donor(name:, address:, zipcode:)
+  context "when the donor is also an admin" do
+    it "hides the promote button" do
+      donor = build_donor(
+        name: "first last",
+        address: "123 fake st.",
+        zipcode: "80205",
+        admin: true,
+      )
+
+      render("users/donors", donors: [donor])
+
+      expect(rendered).not_to have_promote_button
+    end
+  end
+
+  def have_promote_button
+    have_css("[data-role=promote]")
+  end
+
+  def build_donor(name:, address:, zipcode:, admin: false)
     location = build(:location, address: address, zipcode: zipcode)
 
-    build_stubbed(:user, name: name, location: location)
+    build_stubbed(:user, name: name, location: location, admin: admin)
   end
 end


### PR DESCRIPTION

<img width="702" alt="screen shot 2016-04-26 at 5 20 13 pm" src="https://cloud.githubusercontent.com/assets/2575027/14834585/360d472c-0bd3-11e6-9728-c09bd0fa223a.png">
<img width="919" alt="screen shot 2016-04-26 at 5 20 20 pm" src="https://cloud.githubusercontent.com/assets/2575027/14834586/36107758-0bd3-11e6-8656-7e0164a32446.png">
<img width="705" alt="screen shot 2016-04-26 at 5 20 28 pm" src="https://cloud.githubusercontent.com/assets/2575027/14834587/361262b6-0bd3-11e6-81c2-cbfd671f30b8.png">


This commit cleans up the list of Users rendered at `/users`.

Prior to these changes, the `Cyclists` table had links on the left-most
column, while other tables had links and actions in the right-most
column. This commit moves the Cyclist link from the name to a `Register`
action in the right-most column.

When viewing the donors for a particular scheduled pickup, admins will
want to view a donor's donation history. This commit adds a link to
their `/donors/:id` page.