### PR TITLE
Improve validation message for an unsupported ZIP

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,8 +13,9 @@ class ProfilesController < ApplicationController
     if @profile.update(profile_params)
       GeocodeJob.perform_later(@profile.location)
 
-      redirect_to profile_url
+      redirect_to profile_url, flash: { success: t(".success") }
     else
+      flash[:error] = t(".error")
       render :edit
     end
   end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -25,7 +25,7 @@ class Location < ActiveRecord::Base
   validates :location_type, presence: true
   validates :user, presence: true
   validates :zipcode, presence: true, zipcode: { country_code: :us }
-  validates :zone, presence: true
+  validate :zipcode_is_supported
 
   def self.not_geocoded
     where("latitude IS NULL OR longitude IS NULL")
@@ -37,5 +37,16 @@ class Location < ActiveRecord::Base
 
   def zipcode=(zipcode)
     super(zipcode.to_s.strip)
+  end
+
+  private
+
+  def zipcode_is_supported
+    unless Zone.supported?(zipcode)
+      errors[:zipcode] = I18n.t(
+        "validations.locations.unsupported",
+        zipcode: zipcode,
+      )
+    end
   end
 end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -6,7 +6,6 @@ class Registration
     presence: { message: I18n.t("validations.accepted") }
   validates :terms_and_conditions_accepted,
     presence: { message: I18n.t("validations.accepted") }
-  validate :zipcode_is_supported
 
   attr_accessor(
     :address,
@@ -87,12 +86,6 @@ class Registration
 
   def donor_enrollment
     @donor_enrollment ||= DonorEnrollment.new(location: location)
-  end
-
-  def zipcode_is_supported
-    unless zipcode.blank? || Zone.supported?(zipcode)
-      errors[:zipcode] = I18n.t("validations.unsupported", zipcode: zipcode)
-    end
   end
 
   def expose_errors

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,9 @@ en:
     show:
       pickup: "Pickup Info"
       edit: "Edit Personal Info"
+    update:
+      error: "There was an issue updating your personal information."
+      success: "Your personal information has been updated."
 
   promotions:
     create:
@@ -259,7 +262,8 @@ en:
   validations:
     accepted: "must be checked"
     deactivated: "This account has been deactivated."
-    unsupported: "We're sorry, our service is not available in %{zipcode} at this time."
+    locations:
+      unsupported: "%{zipcode} is not supported. Please contact info@freshfoodconnect.org if you have moved or need to change your ZIP code."
 
   zones:
     defaults:

--- a/spec/features/donor_edits_personal_information_spec.rb
+++ b/spec/features/donor_edits_personal_information_spec.rb
@@ -11,6 +11,7 @@ feature "Donor edits personal information" do
     visit root_path(as: donor)
     edit_profile(new_settings)
 
+    expect(page).to have_success_flash
     expect(page).to have_text(new_settings[:email])
     expect(page).to have_text(new_settings[:address])
   end
@@ -24,6 +25,32 @@ feature "Donor edits personal information" do
 
       expect(page).to have_email_errors
     end
+  end
+
+  context "changing to an unsupported zipcode" do
+    it "rejects the change and prompts them to contact the team" do
+      supported_zone = create(:zone, zipcode: "80205")
+      location = create(:location, zipcode: supported_zone.zipcode)
+      donor = create(:donor, location: location)
+
+      visit profile_path(as: donor)
+      edit_profile(zipcode: "80204")
+
+      expect(page).to have_error_flash
+      expect(page).to have_unsupported_zipcode_warning("80204")
+    end
+  end
+
+  def have_unsupported_zipcode_warning(zipcode)
+    have_text t("validations.locations.unsupported", zipcode: zipcode)
+  end
+
+  def have_success_flash
+    have_text t("profiles.update.success")
+  end
+
+  def have_error_flash
+    have_text t("profiles.update.error")
   end
 
   def edit_profile(attributes)

--- a/spec/features/donor_edits_pickup_location_spec.rb
+++ b/spec/features/donor_edits_pickup_location_spec.rb
@@ -25,8 +25,9 @@ feature "Donor edits pickup location" do
     have_css(%{[checked][value="#{value}"]})
   end
 
-  def edit_location(location_type:, grown_on_site:, **attributes)
+  def edit_location(location_type: nil, grown_on_site: nil, **attributes)
     choose option_for(:location_type, location_type)
+
     choose option_for(:grown_on_site, grown_on_site)
 
     fill_form_and_submit(:location, :edit, attributes)

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -18,7 +18,6 @@ describe Location do
   it { should validate_presence_of(:location_type) }
   it { should validate_presence_of(:user) }
   it { should validate_presence_of(:zipcode) }
-  it { should validate_presence_of(:zone) }
 
   it { should validate_numericality_of(:latitude).is_greater_than_or_equal_to(-90) }
   it { should validate_numericality_of(:latitude).is_less_than_or_equal_to(90) }
@@ -27,6 +26,23 @@ describe Location do
   it { should validate_numericality_of(:longitude).is_greater_than_or_equal_to(-180) }
   it { should validate_numericality_of(:longitude).is_less_than_or_equal_to(180) }
   it { should validate_numericality_of(:longitude).allow_nil }
+
+  describe "validations" do
+    it "validates the Zone is supported" do
+      create(:zone, zipcode: "80205")
+      location = build(:location, zipcode: "80204")
+
+      valid = location.valid?
+
+      expect(valid).to be false
+      expect(location.errors[:zipcode]).
+        to eq([unsupported_zipcode_error("80204")])
+    end
+
+    def unsupported_zipcode_error(zipcode)
+      t("validations.locations.unsupported", zipcode: zipcode)
+    end
+  end
 
   describe ".not_geocoded" do
     it "includes Location records without latitude or longitude values" do


### PR DESCRIPTION
https://trello.com/c/KEbZeAQY

Inform donor's that their new ZIP code isn't supported.

Additionally, this commit removes the supported ZIP validation logic
from the `Registration` model, since [this commit][commit] modified the
controller to infer the ZIP code from the URL's dynamic segment instead
of a user-specified value.

[commit]: https://github.com/thoughtbot/freshfoodconnect/commit/6e2adbc40f660f29d0654d78d32528fca79b355c