### PR TITLE
Prevent improper registration or subscription

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,6 @@
 class RegistrationsController < ApplicationController
   skip_before_action :require_login
+  before_action :redirect_if_unsupported, only: [:new]
 
   def new
     @registration = Registration.new(zipcode: zone.zipcode)
@@ -19,8 +20,16 @@ class RegistrationsController < ApplicationController
 
   private
 
+  def redirect_if_unsupported
+    zone = Zone.find_by(zipcode: zipcode)
+
+    if zone.nil?
+      redirect_to new_zone_subscription_url(zipcode)
+    end
+  end
+
   def zone
-    Zone.find_by!(zipcode: params[:zone_id])
+    Zone.find_by!(zipcode: zipcode)
   end
 
   def build_registration
@@ -40,5 +49,9 @@ class RegistrationsController < ApplicationController
         :terms_and_conditions_accepted,
       ).
       merge(zipcode: zone.zipcode)
+  end
+
+  def zipcode
+    params[:zone_id]
   end
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,5 +1,6 @@
 class SubscriptionsController < ApplicationController
   skip_before_action :require_login
+  before_action :redirect_if_supported, only: [:new, :create]
 
   def new
     @subscription = Subscription.new(zipcode: zipcode)
@@ -16,6 +17,12 @@ class SubscriptionsController < ApplicationController
   end
 
   private
+
+  def redirect_if_supported
+    if Zone.supported?(zipcode)
+      redirect_to new_zone_registration_url(zipcode)
+    end
+  end
 
   def build_subscription
     Subscription.new(subscription_params)

--- a/spec/features/donor_signs_up_spec.rb
+++ b/spec/features/donor_signs_up_spec.rb
@@ -21,6 +21,20 @@ feature "Donor signs up" do
     end
   end
 
+  context "for an unsupported ZIP" do
+    scenario "they're redirected to that ZIP's subscribe page" do
+      unsupported_zipcode = "80204"
+
+      visit new_zone_registration_path(unsupported_zipcode)
+
+      expect(current_path).to be_subscription_page_for(unsupported_zipcode)
+    end
+
+    def be_subscription_page_for(zipcode)
+      eq(new_zone_subscription_path(zipcode))
+    end
+  end
+
   context "without accepting the Terms and Conditions" do
     scenario "displays validation errors" do
       zone = create(:zone)

--- a/spec/features/unsupported_donor_subscribes_spec.rb
+++ b/spec/features/unsupported_donor_subscribes_spec.rb
@@ -16,6 +16,20 @@ feature "Unsupported donor subscribes" do
     )
   end
 
+  context "to a supported ZIP" do
+    scenario "they're redirected to the registration page" do
+      supported_zone = create(:zone)
+
+      visit new_zone_subscription_path(supported_zone.zipcode)
+
+      expect(current_path).to be_registration_page_for(supported_zone)
+    end
+
+    def be_registration_page_for(zone)
+      eq(new_zone_registration_path(zone))
+    end
+  end
+
   def have_thank_you_text
     have_text t("pages.thanks.header")
   end


### PR DESCRIPTION
https://trello.com/c/bmqe0NHW

When donor's land on a subscription page for a supported ZIP, or a
registration page for an unsupported ZIP, redirect them to the proper
page.

This change will help preserve our system's data integrity.