### PR TITLE
Require `users.name` column

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ActiveRecord::Base
   has_one :location, dependent: :destroy
 
   validates :email, presence: true, email: true
+  validates :name, presence: true
   validates :organic_growth_asserted_at, presence: {
     message: I18n.t("validations.accepted"),
   }

--- a/db/migrate/20160427170825_require_users_name.rb
+++ b/db/migrate/20160427170825_require_users_name.rb
@@ -1,0 +1,5 @@
+class RequireUsersName < ActiveRecord::Migration
+  def change
+    change_column_null(:users, :name, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160420171312) do
+ActiveRecord::Schema.define(version: 20160427170825) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/cyclist_invitation_spec.rb
+++ b/spec/models/cyclist_invitation_spec.rb
@@ -5,7 +5,7 @@ describe CyclistInvitation do
     context "when valid" do
       it "creates a Cyclist user" do
         ensure_zone_exists!
-        user = User.new(email: "cyclist@example.com")
+        user = build(:user, email: "cyclist@example.com")
         cyclist = CyclistInvitation.new(user)
         password_reset_email = stub_password_reset_email_for(user)
 
@@ -21,7 +21,7 @@ describe CyclistInvitation do
     context "when invalid" do
       it "exposes validation errors" do
         ensure_zone_exists!
-        user = User.new(email: nil)
+        user = build(:user, email: nil)
         cyclist = CyclistInvitation.new(user)
         password_reset_email = stub_password_reset_email_for(user)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,6 +6,7 @@ describe User do
   it { should belong_to(:assigned_zone) }
 
   it { should validate_presence_of(:email) }
+  it { should validate_presence_of(:name) }
   it { should validate_presence_of(:password).on(:create) }
 
   it do


### PR DESCRIPTION
https://trello.com/c/BG7lMD2X

This commit adds a NULL constraint to `users.name`, as well as an
ActiveRecord presence validation.