### PR TITLE
Standardize Pickup Status Copy

### DIFF
--- a/app/assets/stylesheets/_pickup-history.scss
+++ b/app/assets/stylesheets/_pickup-history.scss
@@ -22,4 +22,8 @@
       background-color: $label-font-color;
     }
   }
+
+  &.pending::before {
+    background-color: $brand-orange;
+  }
 }

--- a/app/views/donations/_history.html.erb
+++ b/app/views/donations/_history.html.erb
@@ -1,8 +1,8 @@
 <table>
   <thead>
     <tr>
-      <th>Date</th>
-      <th>Pickup Confirmation</th>
+      <th><%= t(".columns.date") %></th>
+      <th><%= t(".columns.status") %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/scheduled_pickups/_donation.html.erb
+++ b/app/views/scheduled_pickups/_donation.html.erb
@@ -4,5 +4,8 @@
       <%= donation.donor.name %>
     <% end %>
   </td>
-  <td><%= label_for_donation(donation) %></td>
+
+  <td class="pickup-confirmation <%= status_for_pickup(donation) %>">
+    <%= label_for_pickup(donation) %>
+  </td>
 </tr>

--- a/app/views/scheduled_pickups/_donations.html.erb
+++ b/app/views/scheduled_pickups/_donations.html.erb
@@ -20,7 +20,7 @@
   <tbody>
     <%= render(
       partial: "scheduled_pickups/donation",
-      collection: scheduled_pickup.donations.includes(:donor),
+      collection: scheduled_pickup.donations.order(created_at: :asc).includes(:donor),
       as: :donation,
     ) %>
   </tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,6 +85,10 @@ en:
     edit:
       header: "Donation Info"
       prompt: "Would you like to change your donation status?"
+    history:
+      columns:
+        date: "Date"
+        status: "Pickup Confirmation"
     sizes:
       small: "Small"
       medium: "Medium"
@@ -146,7 +150,7 @@ en:
       success: "Donation pickup undone."
     statuses:
       no_donation: "Not donating"
-      pending: "Donating - Not yet picked up"
+      pending: "Donating - Confirmation data not yet entered"
       success: "Picked up"
     update:
       success: "Donation pickup confirmed."


### PR DESCRIPTION



<img width="695" alt="screen shot 2016-04-27 at 5 09 18 pm" src="https://cloud.githubusercontent.com/assets/2575027/14868317/fed6e510-0c9a-11e6-9842-65c1b2e846bb.png">
<img width="698" alt="screen shot 2016-04-27 at 5 09 34 pm" src="https://cloud.githubusercontent.com/assets/2575027/14868318/fedc5888-0c9a-11e6-9b23-622037492143.png">
https://trello.com/c/qFCMb6Qz

Use the same text and status color in both a donor's history and a
week's pickup schedule.