### PR TITLE
Remove Confirm/Decline Flash

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -4,8 +4,6 @@ class ConfirmationsController < ApplicationController
 
     @confirmation.confirm!
 
-    flash[:success] = t(".success")
-
     redirect_to edit_donation_url(@confirmation.donation)
   end
 
@@ -14,8 +12,6 @@ class ConfirmationsController < ApplicationController
 
     @donation.update!(confirmation_params)
 
-    flash[:success] = t(".success")
-
     redirect_to :back
   end
 
@@ -23,8 +19,6 @@ class ConfirmationsController < ApplicationController
     @confirmation = build_confirmation
 
     @confirmation.decline!
-
-    flash[:success] = t(".success")
 
     redirect_to profile_url
   end

--- a/spec/features/donor_confirms_donation_spec.rb
+++ b/spec/features/donor_confirms_donation_spec.rb
@@ -11,9 +11,9 @@ feature "Donor confirms donation" do
 
     expect(last_donation.donor).to belong_to(email)
     expect(last_donation).to be_confirmed
-    expect(page).to have_confirmation_flash
     expect(page).to have_confirmed_status
     expect(page).to have_size_options
+    expect(page).not_to have_flash
   end
 
   scenario "directly from the edit page" do
@@ -31,10 +31,6 @@ feature "Donor confirms donation" do
 
   def have_size_options
     have_text t("simple_form.options.donation.size.medium")
-  end
-
-  def have_confirmation_flash
-    have_text t("confirmations.create.success")
   end
 
   def have_confirmed_status

--- a/spec/features/donor_declines_donation_spec.rb
+++ b/spec/features/donor_declines_donation_spec.rb
@@ -11,9 +11,9 @@ feature "Donor declines donation" do
 
     expect(last_donation).to be_declined
     expect(last_donation.donor).to belong_to(email)
-    expect(page).to have_success_flash
     expect(page).to have_declined_status
     expect(page).to be_redirected_to_profile
+    expect(page).not_to have_flash
   end
 
   def be_redirected_to_profile
@@ -48,10 +48,6 @@ feature "Donor declines donation" do
       declined?: true,
       pending?: false,
     )
-  end
-
-  def have_success_flash
-    have_text t("confirmations.destroy.success")
   end
 
   def have_declined_status

--- a/spec/support/features/matchers.rb
+++ b/spec/support/features/matchers.rb
@@ -1,4 +1,8 @@
 module Features
+  def have_flash
+    have_css("[class*=flash-]")
+  end
+
   def have_name(record)
     if record.respond_to?(:name)
       have_text(record.name.to_s)


### PR DESCRIPTION
https://trello.com/c/1vAb35vS

This commit removes the flash from
`confirmations#{create,update,destroy}` actions.

To prevent future code from re-introducing the flash, assert that NO
flash is on the page.