### PR TITLE
Display Donor's address for Scheduled Pickup

### DIFF
--- a/app/assets/stylesheets/base/_typography.scss
+++ b/app/assets/stylesheets/base/_typography.scss
@@ -46,6 +46,10 @@ a {
   }
 }
 
+address {
+  font-style: normal;
+}
+
 hr {
   border-bottom: $base-border;
   border-left: 0;

--- a/app/views/pickup_checklists/show.html.erb
+++ b/app/views/pickup_checklists/show.html.erb
@@ -21,7 +21,7 @@
       <% @pickup_checklist.donations.each do |donation| %>
         <tr>
           <td data-role="donor"><%= donation.donor.name %></td>
-          <td><%= donation.address %></td>
+          <td><address><%= donation.address %></address></td>
           <td class="btn-cell">
             <% if donation.picked_up? %>
               <%= button_to donation_pickup_path(donation), method: :delete do %>

--- a/app/views/scheduled_pickups/_donation.html.erb
+++ b/app/views/scheduled_pickups/_donation.html.erb
@@ -5,6 +5,10 @@
     <% end %>
   </td>
 
+  <td>
+    <address><%= donation.address %></address>
+  </td>
+
   <td class="pickup-confirmation <%= status_for_pickup(donation) %>">
     <%= label_for_pickup(donation) %>
   </td>

--- a/app/views/scheduled_pickups/_donations.html.erb
+++ b/app/views/scheduled_pickups/_donations.html.erb
@@ -13,6 +13,9 @@
         <%= t(".columns.name") %>
       </th>
       <th>
+        <%= t(".columns.address") %>
+      </th>
+      <th>
         <%= t(".columns.status", date: l(scheduled_pickup.start_at.to_date)) %>
       </th>
     </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,7 @@ en:
     donations:
       checklist: "Cyclist Checklist"
       columns:
+        address: "Address"
         name: "Supplier"
         status: "Donation Status for %{date}"
       header: "Donations"

--- a/spec/views/pickup_checklists/show.html.erb_spec.rb
+++ b/spec/views/pickup_checklists/show.html.erb_spec.rb
@@ -16,6 +16,10 @@ describe "pickup_checklists/show" do
 
     expect(rendered).to have_text("4/14/2016")
     expect(rendered).to have_text(donation.donor.name)
-    expect(rendered).to have_text(donation.address)
+    expect(rendered).to have_address_for(donation)
+  end
+
+  def have_address_for(donation)
+    have_css("address", text: donation.address)
   end
 end


### PR DESCRIPTION

<img width="690" alt="screen shot 2016-04-27 at 5 34 49 pm" src="https://cloud.githubusercontent.com/assets/2575027/14868975/9115869a-0c9e-11e6-96e9-14ce15e99634.png">

https://trello.com/c/zWl8b5X1

Add the `Address` column to the `/zones/:zipcode/donations/:id` page.