### PR TITLE
Attempt to resolve notification bug

### DIFF
--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -37,10 +37,13 @@ class Donation < ActiveRecord::Base
   end
 
   def self.scheduled_for_pick_up_within(hours:)
+    cutoff = hours.hours.from_now
+
     joins(:scheduled_pickup).
       where(
-        "scheduled_pickups.start_at BETWEEN NOW() AND :cutoff",
-        cutoff: hours.hours.from_now,
+        "scheduled_pickups.start_at BETWEEN :now AND :cutoff",
+        now: Time.current,
+        cutoff: cutoff.end_of_day,
       )
   end
 


### PR DESCRIPTION
Staging and Production are scheduled to execute `rake
confirmations:request` at the start of each day (00:00). This commit
introduces some leniency in the "48 hour" window so that a task kicked
off start-of-day Monday will send emails for a pickup scheduled at 08:00
Wednesday morning.

This commit replaces the Postgres-native `NOW()` call with a
Ruby-land `Time.current` value so that we can test and debug using
`Timecop`'s time freezing features.