### PR TITLE
Resolve NoMethodError in Mailer

### DIFF
--- a/app/mailers/donations_mailer.rb
+++ b/app/mailers/donations_mailer.rb
@@ -2,12 +2,13 @@ class DonationsMailer < ApplicationMailer
   def request_confirmation(donation:)
     @confirmation = Confirmation.new(donation)
 
-    reply_to = donation&.location&.zone&.region&.admin&.email || "info@freshfoodconnect.org"
+    admins = donation.zone.admins
+    reply_to = admins.map(&:email).reject(&:blank?).join(",")
 
     mail(
       to: donation.donor.email,
       subject: t(".subject", range: @confirmation.time_range),
-      "Reply-To" => reply_to
+      "Reply-To" => reply_to.presence || "info@freshfoodconnect.org",
     )
   end
 end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -21,6 +21,7 @@ class Zone < ActiveRecord::Base
     uniqueness: { case_sensitive: false },
     zipcode: { country_code: :us }
 
+  has_many :admins, through: :region
   has_many :locations, foreign_key: :zipcode, primary_key: :zipcode
   has_many :scheduled_pickups
   has_many :users, through: :locations

--- a/spec/models/zone_spec.rb
+++ b/spec/models/zone_spec.rb
@@ -16,6 +16,7 @@ describe Zone do
 
   it { should have_many(:locations) }
   it { should have_many(:scheduled_pickups) }
+  it { should have_many(:admins).through(:region) }
   it { should have_many(:users).through(:locations) }
   it { should belong_to(:region) }
 


### PR DESCRIPTION
This commit resolves a typo referencing `Region#admin` instead of the
`has_many` relationship `Region#admins`.